### PR TITLE
adding height offset for touch and put back in config

### DIFF
--- a/pour/config.go
+++ b/pour/config.go
@@ -6,7 +6,7 @@ import (
 	"go.viam.com/rdk/components/arm"
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/components/gripper"
-	toggleswitch "go.viam.com/rdk/components/switch"
+	"go.viam.com/rdk/components/switch"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/services/motion"
 	"go.viam.com/rdk/services/vision"

--- a/pour/config.go
+++ b/pour/config.go
@@ -6,7 +6,7 @@ import (
 	"go.viam.com/rdk/components/arm"
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/components/gripper"
-	"go.viam.com/rdk/components/switch"
+	toggleswitch "go.viam.com/rdk/components/switch"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/services/motion"
 	"go.viam.com/rdk/services/vision"
@@ -66,6 +66,9 @@ type Config struct {
 	BottleHeight float64 `json:"bottle_height"`
 	CupHeight    float64 `json:"cup_height"`
 	CupWidth     float64 `json:"cup_width"`
+
+	// optional offset for gripper height when grabbing/placing cup
+	CupGripHeightOffset float64 `json:"cup_grip_height_offset"`
 
 	PickQualityService   string `json:"pick_quality_service"`
 	PourGlassFindService string `json:"pour_glass_find_service"`
@@ -142,6 +145,13 @@ func (c *Config) glassPourMotionThreshold() float64 {
 		return c.GlassPourMotionThreshold
 	}
 	return 4
+}
+
+func (c *Config) cupGripHeightOffset() float64 {
+	if c.CupGripHeightOffset > 0 {
+		return c.CupGripHeightOffset
+	}
+	return 25
 }
 
 type StagePositions map[string][][]toggleswitch.Switch

--- a/pour/vinocart.go
+++ b/pour/vinocart.go
@@ -607,7 +607,7 @@ func (vc *VinoCart) getApproachPoint(obj *viz.Object, deltaLinear float64, o *sp
 	c := md.Center()
 
 	p := touch.GetApproachPoint(c, deltaLinear, o)
-	p.Z = vc.conf.CupHeight - 25
+	p.Z = vc.conf.CupHeight - vc.conf.cupGripHeightOffset()
 
 	return referenceframe.NewPoseInFrame(
 		"world",
@@ -946,7 +946,7 @@ func (vc *VinoCart) PutBack(ctx context.Context) error {
 		spatialmath.NewPose(r3.Vector{
 			X: cur.Pose().Point().X,
 			Y: cur.Pose().Point().Y,
-			Z: vc.conf.CupHeight - 25,
+			Z: vc.conf.CupHeight - vc.conf.cupGripHeightOffset(),
 		}, cur.Pose().Orientation()))
 
 	_, err = vc.c.Motion.Move(


### PR DESCRIPTION
Adding a config parameter for the offset from cup_height used by the "touch" and "put back" steps to set the exact height to grab the glass. Currently it is hardcoded as 25mm. 