### PR TITLE
Improve reset functionality

### DIFF
--- a/pour/vinocart.go
+++ b/pour/vinocart.go
@@ -315,18 +315,6 @@ func (vc *VinoCart) Reset(ctx context.Context) error {
 			if err != nil {
 				return err
 			}
-		} else {
-			err = vc.c.Gripper.Open(ctx, nil)
-			if err != nil {
-				return err
-			}
-
-			time.Sleep(time.Millisecond * 500)
-
-			err = vc.doAll(ctx, "reset", "left-not-holding-post", 100)
-			if err != nil {
-				return err
-			}
 		}
 		return nil
 	})
@@ -351,25 +339,17 @@ func (vc *VinoCart) Reset(ctx context.Context) error {
 				return err
 			}
 
-		} else {
-			err = vc.c.BottleGripper.Open(ctx, nil)
-			if err != nil {
-				return err
-			}
-
-			time.Sleep(time.Millisecond * 500)
-
-			err = vc.doAll(ctx, "reset", "right-not-holding-post", 100)
-			if err != nil {
-				return err
-			}
 		}
 		return nil
 	})
 
 	err2 := g.Wait()
+	if err2 != nil {
+		return err2
+	}
+	err3 := vc.doAll(ctx, "touch", "prep", 100)
 
-	return err2
+	return err3
 }
 
 func (vc *VinoCart) GrabCup(ctx context.Context) error {

--- a/pour/vinocart.go
+++ b/pour/vinocart.go
@@ -284,15 +284,88 @@ func (vc *VinoCart) FullDemo(ctx context.Context) error {
 func (vc *VinoCart) Reset(ctx context.Context) error {
 	g := errgroup.Group{}
 
+	cupHoldingStatus, err := vc.c.Gripper.IsHoldingSomething(ctx, nil)
+	if err != nil {
+		return err
+	}
+	bottleHoldingStatus, err := vc.c.BottleGripper.IsHoldingSomething(ctx, nil)
+	if err != nil {
+		return err
+	}
 	g.Go(func() error {
-		return vc.c.Gripper.Open(ctx, nil)
+		if cupHoldingStatus.IsHoldingSomething {
+			err = vc.doAll(ctx, "reset", "left-holding-pre", 50)
+			if err != nil {
+				return err
+			}
+			cur, err := vc.c.Motion.GetPose(ctx, vc.conf.GripperName, "world", vc.pourExtraFrames, nil)
+			if err != nil {
+				return err
+			}
+
+			cur = referenceframe.NewPoseInFrame(
+				cur.Parent(),
+				spatialmath.NewPose(r3.Vector{
+					X: cur.Pose().Point().X,
+					Y: cur.Pose().Point().Y,
+					Z: vc.conf.CupHeight - vc.conf.cupGripHeightOffset(),
+				}, cur.Pose().Orientation()))
+
+			_, err = vc.c.Motion.Move(
+				ctx,
+				motion.MoveReq{
+					ComponentName: vc.conf.GripperName,
+					Destination:   cur,
+				},
+			)
+			if err != nil {
+				return err
+			}
+
+			err = vc.c.Gripper.Open(ctx, nil)
+			if err != nil {
+				return err
+			}
+			time.Sleep(time.Millisecond * 500)
+			err = vc.doAll(ctx, "reset", "left-holding-post", 50)
+			if err != nil {
+				return err
+			}
+		} else {
+			err = vc.c.Gripper.Open(ctx, nil)
+			if err != nil {
+				return err
+			}
+			err = vc.doAll(ctx, "reset", "left-not-holding-post", 100)
+		}
+		return nil
 	})
 
 	g.Go(func() error {
-		return vc.c.BottleGripper.Open(ctx, nil)
+		if bottleHoldingStatus.IsHoldingSomething {
+			err = vc.doAll(ctx, "reset", "right-holding-pre", 50)
+			if err != nil {
+				return err
+			}
+			err = vc.c.BottleGripper.Open(ctx, nil)
+			if err != nil {
+				return err
+			}
+			time.Sleep(time.Millisecond * 500)
+			err = vc.doAll(ctx, "reset", "right-holding-post", 50)
+			if err != nil {
+				return err
+			}
+		} else {
+			err = vc.c.BottleGripper.Open(ctx, nil)
+			if err != nil {
+				return err
+			}
+			err = vc.doAll(ctx, "reset", "right-not-holding-post", 100)
+		}
+		return nil
 	})
 
-	err := vc.doAll(ctx, "touch", "prep", 100)
 	err2 := g.Wait()
 
 	return multierr.Combine(err, err2)

--- a/pour/vinocart.go
+++ b/pour/vinocart.go
@@ -308,6 +308,7 @@ func (vc *VinoCart) Reset(ctx context.Context) error {
 			if err != nil {
 				return err
 			}
+
 			time.Sleep(time.Millisecond * 500)
 			err = vc.doAll(ctx, "reset", "left-holding-post", 50)
 			if err != nil {
@@ -315,11 +316,16 @@ func (vc *VinoCart) Reset(ctx context.Context) error {
 			}
 		} else {
 			err = vc.c.Gripper.Open(ctx, nil)
-			time.Sleep(time.Millisecond * 500)
 			if err != nil {
 				return err
 			}
+
+			time.Sleep(time.Millisecond * 500)
+
 			err = vc.doAll(ctx, "reset", "left-not-holding-post", 100)
+			if err != nil {
+				return err
+			}
 		}
 		return nil
 	})
@@ -330,22 +336,31 @@ func (vc *VinoCart) Reset(ctx context.Context) error {
 			if err != nil {
 				return err
 			}
+
 			err = vc.c.BottleGripper.Open(ctx, nil)
 			if err != nil {
 				return err
 			}
+
 			time.Sleep(time.Millisecond * 500)
+
 			err = vc.doAll(ctx, "reset", "right-holding-post", 50)
 			if err != nil {
 				return err
 			}
+
 		} else {
 			err = vc.c.BottleGripper.Open(ctx, nil)
-			time.Sleep(time.Millisecond * 500)
 			if err != nil {
 				return err
 			}
+
+			time.Sleep(time.Millisecond * 500)
+
 			err = vc.doAll(ctx, "reset", "right-not-holding-post", 100)
+			if err != nil {
+				return err
+			}
 		}
 		return nil
 	})

--- a/pour/vinocart.go
+++ b/pour/vinocart.go
@@ -333,6 +333,7 @@ func (vc *VinoCart) Reset(ctx context.Context) error {
 			}
 		} else {
 			err = vc.c.Gripper.Open(ctx, nil)
+			time.Sleep(time.Millisecond * 500)
 			if err != nil {
 				return err
 			}
@@ -358,6 +359,7 @@ func (vc *VinoCart) Reset(ctx context.Context) error {
 			}
 		} else {
 			err = vc.c.BottleGripper.Open(ctx, nil)
+			time.Sleep(time.Millisecond * 500)
 			if err != nil {
 				return err
 			}

--- a/pour/vinocart.go
+++ b/pour/vinocart.go
@@ -293,6 +293,7 @@ func (vc *VinoCart) Reset(ctx context.Context) error {
 		return err
 	}
 	g.Go(func() error {
+		var err error
 		if cupHoldingStatus.IsHoldingSomething {
 			err = vc.doAll(ctx, "reset", "left-holding-pre", 50)
 			if err != nil {
@@ -331,6 +332,7 @@ func (vc *VinoCart) Reset(ctx context.Context) error {
 	})
 
 	g.Go(func() error {
+		var err error
 		if bottleHoldingStatus.IsHoldingSomething {
 			err = vc.doAll(ctx, "reset", "right-holding-pre", 50)
 			if err != nil {
@@ -367,7 +369,7 @@ func (vc *VinoCart) Reset(ctx context.Context) error {
 
 	err2 := g.Wait()
 
-	return multierr.Combine(err, err2)
+	return err2
 }
 
 func (vc *VinoCart) GrabCup(ctx context.Context) error {


### PR DESCRIPTION
**Changes:**
- Remove unconditional opening of both grippers on Reset command
- Handle Reset logic separately for each arm
- Handle Reset logic conditionally based on weather the arm is holding bottle/glass when Reset is called
- Create a helper `moveToCurrentXYAtCupHeight` and use it in `PutBack` and `Reset` methods to put the glass at the correct height

Module update requires adding the following position sequences to `cart` config to enable Reset:
```json
"reset": {
      "left-holding-pre": [
        [
          "arm-left-put-back1"
        ]
      ],
      "left-holding-post": [
        [
          "arm-left-put-back2"
        ],
        [
          "arm-left-put-back3"
        ],
        [
          "arm-left-watch-pose"
        ]
      ],
      "right-holding-pre": [
        [
          "arm-right-bottle-right-prep4"
        ]
      ],
      "right-holding-post": [
        [
          "arm-right-bottle-right-prep3"
        ],
        [
          "arm-right-bottle-prep2"
        ],
        [
          "arm-right-watch-pose"
        ]
      ],
      "left-not-holding-post": [
        [
          "arm-left-watch-pose"
        ]
      ],
      "right-not-holding-post": [
        [
          "arm-right-watch-pose"
        ]
      ]
    }
```