### PR TITLE
change names of components with fragment update

### DIFF
--- a/pour/vinoweb/src/RobotApp.svelte
+++ b/pour/vinoweb/src/RobotApp.svelte
@@ -63,7 +63,7 @@
       joints: leftJoints,
       tableTitle: "Left Arm",
       camera: {
-        name: "cam-left",
+        name: "left-camera",
         partID: "xxx",
         label: "Left Camera",
       },
@@ -72,7 +72,7 @@
       joints: rightJoints,
       tableTitle: "Right Arm",
       camera: {
-        name: "cam-right",
+        name: "right-camera",
         partID: "xxx",
         label: "Right Camera",
       },
@@ -93,8 +93,8 @@
     const robotClient = robotClientStore.current;
     $inspect(robotClient, "robotClient");
     if (robotClient && !pollingHandle) {
-      if (!leftArm) leftArm = new ArmClient(robotClient, "arm-left");
-      if (!rightArm) rightArm = new ArmClient(robotClient, "arm-right");
+      if (!leftArm) leftArm = new ArmClient(robotClient, "left-arm");
+      if (!rightArm) rightArm = new ArmClient(robotClient, "right-arm");
       if (!generic) generic = new GenericServiceClient(robotClient, "cart");
 
       pollingHandle = setInterval(async () => {

--- a/pour/vinoweb/src/RobotApp.svelte
+++ b/pour/vinoweb/src/RobotApp.svelte
@@ -63,7 +63,7 @@
       joints: leftJoints,
       tableTitle: "Left Arm",
       camera: {
-        name: "left-camera",
+        name: "left-cam",
         partID: "xxx",
         label: "Left Camera",
       },
@@ -72,7 +72,7 @@
       joints: rightJoints,
       tableTitle: "Right Arm",
       camera: {
-        name: "right-camera",
+        name: "right-cam",
         partID: "xxx",
         label: "Right Camera",
       },

--- a/pour/vinoweb/src/componentPreview.svelte
+++ b/pour/vinoweb/src/componentPreview.svelte
@@ -28,7 +28,7 @@
     ];
 
     const mockCamera = {
-        name: "cam-left",
+        name: "left-cam",
         partID: "xxx",
         label: "Camera 1",
     };
@@ -38,7 +38,7 @@
             joints: sampleJoints,
             tableTitle: "Robot Arm 1",
             camera: {
-                name: "cam-left",
+                name: "left-cam",
                 partID: "xxx",
                 label: "Camera 1",
             },
@@ -47,7 +47,7 @@
             joints: sampleJoints,
             tableTitle: "Robot Arm 2",
             camera: {
-                name: "cam-right",
+                name: "right-cam",
                 partID: "xxx",
                 label: "Camera 2",
             },


### PR DESCRIPTION
names of these components had been hardcoded into the webapp. since the upgrade to use fragment prefixes in the config, the names have changed and need to be updated. otherwise the app shows blank screens and no updating joint positions

tested this out on the cart with reload, works as expected