### PR TITLE
Add Cup Detection Loop

### DIFF
--- a/cmd/tools/cmd-tools.go
+++ b/cmd/tools/cmd-tools.go
@@ -150,6 +150,8 @@ func realMain() error {
 	case "sleep":
 		time.Sleep(time.Minute * 5)
 		return nil
+	case "loop":
+		return vc.Loop(ctx)
 
 	case "pose":
 		left, err := getAPose(ctx, client, "april-tag-tracker-left", "7")


### PR DESCRIPTION
Adds a continuous loop mode that automatically triggers a pour when a cup is detected, waits for the filled cup to be removed, then immediately starts the next pour without requiring manual intervention between cycles.