### PR TITLE
use calibration-checker sensor for april tag calibration

### DIFF
--- a/cmd/tools/cmd-tools.go
+++ b/cmd/tools/cmd-tools.go
@@ -96,18 +96,18 @@ func realMain() error {
 	case "reset":
 		return vc.Reset(ctx)
 	case "touch":
-		return vc.Touch(ctx)
+		return vc.TouchCup(ctx)
 	case "pour-prep":
 		return vc.PourPrep(ctx)
 	case "touch-and-prep":
-		err := vc.Touch(ctx)
+		err := vc.TouchCup(ctx)
 		if err != nil {
 			return err
 		}
 		return vc.PourPrep(ctx)
 	case "touch-and-reset":
 		for i := 0; i < n; i++ {
-			err := vc.Touch(ctx)
+			err := vc.TouchCup(ctx)
 			if err != nil {
 				logger.Infof("error touching, continuing: %v", err)
 				continue

--- a/cmd/tools/cmd-tools.go
+++ b/cmd/tools/cmd-tools.go
@@ -96,18 +96,18 @@ func realMain() error {
 	case "reset":
 		return vc.Reset(ctx)
 	case "touch":
-		return vc.TouchCup(ctx)
+		return vc.Touch(ctx)
 	case "pour-prep":
 		return vc.PourPrep(ctx)
 	case "touch-and-prep":
-		err := vc.TouchCup(ctx)
+		err := vc.Touch(ctx)
 		if err != nil {
 			return err
 		}
 		return vc.PourPrep(ctx)
 	case "touch-and-reset":
 		for i := 0; i < n; i++ {
-			err := vc.TouchCup(ctx)
+			err := vc.Touch(ctx)
 			if err != nil {
 				logger.Infof("error touching, continuing: %v", err)
 				continue

--- a/pour/config.go
+++ b/pour/config.go
@@ -75,10 +75,23 @@ type Config struct {
 	PickQualityService   string `json:"pick_quality_service"`
 	PourGlassFindService string `json:"pour_glass_find_service"`
 
-	// Optional: PoseTracker for the center divider AprilTag
-	AprilTagService string `json:"april_tag_service"`
-	// Tag body name to query (default "0")
-	AprilTagID string `json:"april_tag_id"`
+	// Optional: PoseTracker for the center AprilTag (right camera)
+	AprilTagServiceRight string `json:"april_tag_service_right"`
+	// Optional: PoseTracker for the center AprilTag (left camera)
+	AprilTagServiceLeft string `json:"april_tag_service_left"`
+	// Tag body name to query for both cameras (default "0")
+	AprilTagIDCenter string `json:"april_tag_id_center"`
+	// Expected tag position in camera frame when right arm is correctly positioned
+	ExpectedTagX float64 `json:"expected_tag_x"`
+	ExpectedTagY float64 `json:"expected_tag_y"`
+	ExpectedTagZ float64 `json:"expected_tag_z"`
+	// Expected tag position in camera frame when left arm is correctly positioned
+	ExpectedTagXLeft float64 `json:"expected_tag_x_left"`
+	ExpectedTagYLeft float64 `json:"expected_tag_y_left"`
+	ExpectedTagZLeft float64 `json:"expected_tag_z_left"`
+
+	// Max allowed deviation from expected tag position in mm (default 10)
+	TagToleranceMM float64 `json:"tag_tolerance_mm"`
 
 	Loop bool `json:"loop"`
 }
@@ -137,8 +150,12 @@ func (cfg *Config) Validate(path string) ([]string, []string, error) {
 		deps = append(deps, cfg.GlassPourCam)
 	}
 
-	if cfg.AprilTagService != "" {
-		optionals = append(optionals, cfg.AprilTagService)
+	if cfg.AprilTagServiceRight != "" {
+		optionals = append(optionals, cfg.AprilTagServiceRight)
+	}
+
+	if cfg.AprilTagServiceLeft != "" {
+		optionals = append(optionals, cfg.AprilTagServiceLeft)
 	}
 
 	return deps, optionals, nil
@@ -156,6 +173,13 @@ func (c *Config) glassPourMotionThreshold() float64 {
 		return c.GlassPourMotionThreshold
 	}
 	return 4
+}
+
+func (c *Config) tagToleranceMM() float64 {
+	if c.TagToleranceMM > 0 {
+		return c.TagToleranceMM
+	}
+	return 10
 }
 
 func (c *Config) cupGripHeightOffset() float64 {
@@ -187,7 +211,8 @@ type Pour1Components struct {
 	PickQualityService   vision.Service
 	PourGlassFindService vision.Service
 
-	AprilTagTracker posetracker.PoseTracker
+	AprilTagTracker     posetracker.PoseTracker
+	AprilTagTrackerLeft posetracker.PoseTracker
 }
 
 func Pour1ComponentsFromDependencies(config *Config, deps resource.Dependencies) (*Pour1Components, error) {
@@ -240,8 +265,15 @@ func Pour1ComponentsFromDependencies(config *Config, deps resource.Dependencies)
 		}
 	}
 
-	if config.AprilTagService != "" {
-		c.AprilTagTracker, err = posetracker.FromDependencies(deps, config.AprilTagService)
+	if config.AprilTagServiceRight != "" {
+		c.AprilTagTracker, err = posetracker.FromDependencies(deps, config.AprilTagServiceRight)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if config.AprilTagServiceLeft != "" {
+		c.AprilTagTrackerLeft, err = posetracker.FromDependencies(deps, config.AprilTagServiceLeft)
 		if err != nil {
 			return nil, err
 		}

--- a/pour/config.go
+++ b/pour/config.go
@@ -6,7 +6,8 @@ import (
 	"go.viam.com/rdk/components/arm"
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/components/gripper"
-	"go.viam.com/rdk/components/switch"
+	"go.viam.com/rdk/components/posetracker"
+	toggleswitch "go.viam.com/rdk/components/switch"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/robot/framesystem"
 	"go.viam.com/rdk/services/motion"
@@ -74,6 +75,11 @@ type Config struct {
 	PickQualityService   string `json:"pick_quality_service"`
 	PourGlassFindService string `json:"pour_glass_find_service"`
 
+	// Optional: PoseTracker for the center divider AprilTag
+	AprilTagService string `json:"april_tag_service"`
+	// Tag body name to query (default "0")
+	AprilTagID string `json:"april_tag_id"`
+
 	Loop bool `json:"loop"`
 }
 
@@ -131,6 +137,10 @@ func (cfg *Config) Validate(path string) ([]string, []string, error) {
 		deps = append(deps, cfg.GlassPourCam)
 	}
 
+	if cfg.AprilTagService != "" {
+		optionals = append(optionals, cfg.AprilTagService)
+	}
+
 	return deps, optionals, nil
 }
 
@@ -176,6 +186,8 @@ type Pour1Components struct {
 
 	PickQualityService   vision.Service
 	PourGlassFindService vision.Service
+
+	AprilTagTracker posetracker.PoseTracker
 }
 
 func Pour1ComponentsFromDependencies(config *Config, deps resource.Dependencies) (*Pour1Components, error) {
@@ -223,6 +235,13 @@ func Pour1ComponentsFromDependencies(config *Config, deps resource.Dependencies)
 
 	if config.PourGlassFindService != "" {
 		c.PourGlassFindService, err = vision.FromDependencies(deps, config.PourGlassFindService)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if config.AprilTagService != "" {
+		c.AprilTagTracker, err = posetracker.FromDependencies(deps, config.AprilTagService)
 		if err != nil {
 			return nil, err
 		}

--- a/pour/config.go
+++ b/pour/config.go
@@ -75,22 +75,19 @@ type Config struct {
 	PickQualityService   string `json:"pick_quality_service"`
 	PourGlassFindService string `json:"pour_glass_find_service"`
 
+	// Optional: PoseTracker for the gripper AprilTag visible to glass-cam during pour
+	GlassPourAprilTagService string `json:"glass_pour_april_tag_service"`
+	// AprilTag ID to query from the gripper tracker (default "0")
+	GlassPourAprilTagID string `json:"glass_pour_april_tag_id"`
+
 	// Optional: PoseTracker for the center AprilTag (right camera)
 	AprilTagServiceRight string `json:"april_tag_service_right"`
 	// Optional: PoseTracker for the center AprilTag (left camera)
 	AprilTagServiceLeft string `json:"april_tag_service_left"`
 	// Tag body name to query for both cameras (default "0")
 	AprilTagIDCenter string `json:"april_tag_id_center"`
-	// Expected tag position in camera frame when right arm is correctly positioned
-	ExpectedTagX float64 `json:"expected_tag_x"`
-	ExpectedTagY float64 `json:"expected_tag_y"`
-	ExpectedTagZ float64 `json:"expected_tag_z"`
-	// Expected tag position in camera frame when left arm is correctly positioned
-	ExpectedTagXLeft float64 `json:"expected_tag_x_left"`
-	ExpectedTagYLeft float64 `json:"expected_tag_y_left"`
-	ExpectedTagZLeft float64 `json:"expected_tag_z_left"`
 
-	// Max allowed deviation from expected tag position in mm (default 10)
+	// Max allowed deviation between the two cameras' world-frame tag positions in mm (default 10)
 	TagToleranceMM float64 `json:"tag_tolerance_mm"`
 
 	Loop bool `json:"loop"`
@@ -158,6 +155,10 @@ func (cfg *Config) Validate(path string) ([]string, []string, error) {
 		optionals = append(optionals, cfg.AprilTagServiceLeft)
 	}
 
+	if cfg.GlassPourAprilTagService != "" {
+		optionals = append(optionals, cfg.GlassPourAprilTagService)
+	}
+
 	return deps, optionals, nil
 }
 
@@ -213,6 +214,8 @@ type Pour1Components struct {
 
 	AprilTagTracker     posetracker.PoseTracker
 	AprilTagTrackerLeft posetracker.PoseTracker
+
+	GlassPourAprilTagTracker posetracker.PoseTracker
 }
 
 func Pour1ComponentsFromDependencies(config *Config, deps resource.Dependencies) (*Pour1Components, error) {
@@ -274,6 +277,13 @@ func Pour1ComponentsFromDependencies(config *Config, deps resource.Dependencies)
 
 	if config.AprilTagServiceLeft != "" {
 		c.AprilTagTrackerLeft, err = posetracker.FromDependencies(deps, config.AprilTagServiceLeft)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if config.GlassPourAprilTagService != "" {
+		c.GlassPourAprilTagTracker, err = posetracker.FromDependencies(deps, config.GlassPourAprilTagService)
 		if err != nil {
 			return nil, err
 		}

--- a/pour/config.go
+++ b/pour/config.go
@@ -7,7 +7,9 @@ import (
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/components/gripper"
 	"go.viam.com/rdk/components/posetracker"
+	"go.viam.com/rdk/components/sensor"
 	toggleswitch "go.viam.com/rdk/components/switch"
+	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/robot/framesystem"
 	"go.viam.com/rdk/services/motion"
@@ -80,15 +82,8 @@ type Config struct {
 	// AprilTag ID to query from the gripper tracker (default "0")
 	GlassPourAprilTagID string `json:"glass_pour_april_tag_id"`
 
-	// Optional: PoseTracker for the center AprilTag (right camera)
-	AprilTagServiceRight string `json:"april_tag_service_right"`
-	// Optional: PoseTracker for the center AprilTag (left camera)
-	AprilTagServiceLeft string `json:"april_tag_service_left"`
-	// Tag body name to query for both cameras (default "0")
-	AprilTagIDCenter string `json:"april_tag_id_center"`
-
-	// Max allowed deviation between the two cameras' world-frame tag positions in mm (default 10)
-	TagToleranceMM float64 `json:"tag_tolerance_mm"`
+	// Optional: calibration-checker sensor from vmodutils
+	CalibrationSensor string `json:"calibration_sensor"`
 
 	Loop bool `json:"loop"`
 }
@@ -147,12 +142,8 @@ func (cfg *Config) Validate(path string) ([]string, []string, error) {
 		deps = append(deps, cfg.GlassPourCam)
 	}
 
-	if cfg.AprilTagServiceRight != "" {
-		optionals = append(optionals, cfg.AprilTagServiceRight)
-	}
-
-	if cfg.AprilTagServiceLeft != "" {
-		optionals = append(optionals, cfg.AprilTagServiceLeft)
+	if cfg.CalibrationSensor != "" {
+		optionals = append(optionals, cfg.CalibrationSensor)
 	}
 
 	if cfg.GlassPourAprilTagService != "" {
@@ -174,13 +165,6 @@ func (c *Config) glassPourMotionThreshold() float64 {
 		return c.GlassPourMotionThreshold
 	}
 	return 4
-}
-
-func (c *Config) tagToleranceMM() float64 {
-	if c.TagToleranceMM > 0 {
-		return c.TagToleranceMM
-	}
-	return 10
 }
 
 func (c *Config) cupGripHeightOffset() float64 {
@@ -212,15 +196,20 @@ type Pour1Components struct {
 	PickQualityService   vision.Service
 	PourGlassFindService vision.Service
 
-	AprilTagTracker     posetracker.PoseTracker
-	AprilTagTrackerLeft posetracker.PoseTracker
+	CalibrationSensor sensor.Sensor
 
 	GlassPourAprilTagTracker posetracker.PoseTracker
 }
 
-func Pour1ComponentsFromDependencies(config *Config, deps resource.Dependencies) (*Pour1Components, error) {
+func Pour1ComponentsFromDependencies(config *Config, deps resource.Dependencies, logger ...logging.Logger) (*Pour1Components, error) {
 	var err error
 	c := &Pour1Components{}
+
+	warnOptional := func(name, kind string, err error) {
+		if len(logger) > 0 && logger[0] != nil {
+			logger[0].Warnf("optional dependency %s (%s) not available: %v", name, kind, err)
+		}
+	}
 
 	c.Arm, err = arm.FromDependencies(deps, config.ArmName)
 	if err != nil {
@@ -268,31 +257,24 @@ func Pour1ComponentsFromDependencies(config *Config, deps resource.Dependencies)
 		}
 	}
 
-	if config.AprilTagServiceRight != "" {
-		c.AprilTagTracker, err = posetracker.FromDependencies(deps, config.AprilTagServiceRight)
+	if config.CalibrationSensor != "" {
+		c.CalibrationSensor, err = sensor.FromDependencies(deps, config.CalibrationSensor)
 		if err != nil {
-			return nil, err
-		}
-	}
-
-	if config.AprilTagServiceLeft != "" {
-		c.AprilTagTrackerLeft, err = posetracker.FromDependencies(deps, config.AprilTagServiceLeft)
-		if err != nil {
-			return nil, err
+			warnOptional(config.CalibrationSensor, "calibration sensor", err)
 		}
 	}
 
 	if config.GlassPourAprilTagService != "" {
 		c.GlassPourAprilTagTracker, err = posetracker.FromDependencies(deps, config.GlassPourAprilTagService)
 		if err != nil {
-			return nil, err
+			warnOptional(config.GlassPourAprilTagService, "pose tracker", err)
 		}
 	}
 
 	if config.CupFinderService != "" {
 		c.CupFinder, err = vision.FromDependencies(deps, config.CupFinderService)
 		if err != nil {
-			return nil, err
+			warnOptional(config.CupFinderService, "cup finder", err)
 		}
 	}
 

--- a/pour/config.go
+++ b/pour/config.go
@@ -71,9 +71,6 @@ type Config struct {
 	CupHeight    float64 `json:"cup_height"`
 	CupWidth     float64 `json:"cup_width"`
 
-	// optional offset for gripper height when grabbing/placing cup
-	CupGripHeightOffset float64 `json:"cup_grip_height_offset"`
-
 	PickQualityService   string `json:"pick_quality_service"`
 	PourGlassFindService string `json:"pour_glass_find_service"`
 
@@ -165,13 +162,6 @@ func (c *Config) glassPourMotionThreshold() float64 {
 		return c.GlassPourMotionThreshold
 	}
 	return 4
-}
-
-func (c *Config) cupGripHeightOffset() float64 {
-	if c.CupGripHeightOffset > 0 {
-		return c.CupGripHeightOffset
-	}
-	return 25
 }
 
 type StagePositions map[string][][]toggleswitch.Switch

--- a/pour/vinocart.go
+++ b/pour/vinocart.go
@@ -212,6 +212,7 @@ func (vc *VinoCart) DoCommand(ctx context.Context, cmd map[string]interface{}) (
 	if cmd["demo"] == true {
 		return nil, vc.FullDemo(ctx)
 	}
+
 	if cmd["test_position"] != nil {
 		positionCmd, ok := cmd["test_position"].(map[string]interface{})
 		if !ok {

--- a/pour/vinocart.go
+++ b/pour/vinocart.go
@@ -1086,7 +1086,7 @@ func (vc *VinoCart) Pour(ctx context.Context) error {
 				vc.logger.Warnf("[bottle-to-cup-align][try %d] debug written to %s", try, fn)
 			}
 			lastErr = fmt.Errorf("[bottle-to-cup-align][try %d] pos too far: %v", try, alignL2)
-			// On all but the final try, replan 
+			// On all but the final try, replan
 			if try < maxAlignTries {
 				vc.logger.Warnf("[bottle-to-cup-align][try %d] L2 too high, replanning...", try)
 				alignPlan, _, err = armplanning.PlanMotion(ctx, vc.logger, alignReq)
@@ -1485,7 +1485,6 @@ func (vc *VinoCart) getTagPosition(ctx context.Context) (map[string]interface{},
 
 	return result, nil
 }
-
 
 // checkAprilTagCalibration checks that the left and right cameras agree on
 // the center AprilTag's world-frame position. If they disagree by more than

--- a/pour/vinocart.go
+++ b/pour/vinocart.go
@@ -205,7 +205,7 @@ func (vc *VinoCart) DoCommand(ctx context.Context, cmd map[string]interface{}) (
 	}
 
 	if cmd["touch"] == true {
-		return nil, vc.TouchCup(ctx)
+		return nil, vc.Touch(ctx)
 	}
 
 	if cmd["pour-prep"] == true {
@@ -322,7 +322,7 @@ func (vc *VinoCart) WaitForCupAndGo(ctx context.Context) error {
 }
 
 func (vc *VinoCart) FullDemo(ctx context.Context) error {
-	err := vc.TouchCup(ctx)
+	err := vc.Touch(ctx)
 	if err != nil {
 		return err
 	}
@@ -561,13 +561,8 @@ func saveImageToDataset(ctx context.Context, component resource.Name, img image.
 	return nil
 }
 
-func (vc *VinoCart) TouchCup(ctx context.Context) error {
-	if err := vc.checkAprilTagCalibration(ctx); err != nil {
-		vc.setStatusWithMessage("error", err.Error())
-		return err
-	}
-
-	vc.setStatusWithMessage("looking", "Looking for cups")
+func (vc *VinoCart) Touch(ctx context.Context) error {
+	vc.setStatus("looking")
 
 	err := vc.Reset(ctx)
 	if err != nil {
@@ -740,7 +735,7 @@ func (vc *VinoCart) handoffCupBottleToCupArm(ctx context.Context, worldState *re
 			return err
 		}
 
-		return vc.TouchCup(ctx)
+		return vc.Touch(ctx)
 	}
 	return fmt.Errorf("no path for handoff")
 }
@@ -1555,4 +1550,3 @@ func (vc *VinoCart) FindCups(ctx context.Context) ([]*viz.Object, error) {
 
 	return FilterObjects(objects, vc.conf.CupHeight, vc.conf.cupWidth(), 15, "FindCups", vc.logger), nil
 }
-

--- a/pour/vinocart.go
+++ b/pour/vinocart.go
@@ -8,8 +8,10 @@ import (
 	"image"
 	"image/png"
 	"io/fs"
+	"math"
 	"net/http"
 	"os"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -47,6 +49,8 @@ const cupTopName = "cup-top"
 const gripperToCupCenterHack float64 = -35
 
 var VinoCartModel = NamespaceFamily.WithModel("vinocart")
+var noCupObjects = fmt.Errorf("no cup objects")
+var noBottleObjects = fmt.Errorf("no bottle objects")
 var noObjects = fmt.Errorf("no objects")
 
 func init() {
@@ -156,6 +160,7 @@ type VinoCart struct {
 
 	statusLock sync.Mutex
 	status     string
+	message    string
 
 	server *http.Server
 }
@@ -175,15 +180,11 @@ func (vc *VinoCart) Close(ctx context.Context) error {
 
 func (vc *VinoCart) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
 	if cmd["status"] == true {
-		return map[string]interface{}{"status": vc.getStatus()}, nil
+		return vc.getStatus(), nil
 	}
 
 	if cmd["stop"] == true {
 		return nil, multierr.Combine(vc.c.Arm.Stop(ctx, nil), vc.c.BottleArm.Stop(ctx, nil))
-	}
-
-	if cmd["get_tag_position"] == true {
-		return vc.getTagPosition(ctx)
 	}
 
 	if vc.loopCancel != nil {
@@ -191,8 +192,15 @@ func (vc *VinoCart) DoCommand(ctx context.Context, cmd map[string]interface{}) (
 	}
 
 	defer func() {
+		if r := recover(); r != nil {
+			vc.logger.Errorf("DoCommand panic: %v\n%s", r, debug.Stack())
+		}
 		vc.setStatus("manual mode")
 	}()
+
+	if cmd["get_tag_position"] == true {
+		return vc.getTagPosition(ctx)
+	}
 
 	if cmd["reset"] == true {
 		return nil, vc.Reset(ctx)
@@ -261,17 +269,25 @@ func (vc *VinoCart) run(ctx context.Context) {
 	}
 }
 
-func (vc *VinoCart) getStatus() string {
+func (vc *VinoCart) getStatus() map[string]interface{} {
 	vc.statusLock.Lock()
 	defer vc.statusLock.Unlock()
-	return vc.status
+	return map[string]interface{}{
+		"status":  vc.status,
+		"message": vc.message,
+	}
 }
 
 func (vc *VinoCart) setStatus(s string) {
-	vc.logger.Infof("setStatus: %v", s)
+	vc.setStatusWithMessage(s, "")
+}
+
+func (vc *VinoCart) setStatusWithMessage(s string, msg string) {
+	vc.logger.Infof("setStatus: %v (message: %v)", s, msg)
 	vc.statusLock.Lock()
 	defer vc.statusLock.Unlock()
 	vc.status = s
+	vc.message = msg
 }
 
 func (vc *VinoCart) WaitForCupAndGo(ctx context.Context) error {
@@ -1112,6 +1128,7 @@ func (vc *VinoCart) Pour(ctx context.Context) error {
 	markedDifferent := false
 
 	pourContext, cancelPour := context.WithCancel(ctx)
+	defer cancelPour()
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 
@@ -1422,10 +1439,8 @@ func moveWithLinearConstraint(ctx context.Context, m motion.Service, n resource.
 
 // checkAprilTagCalibration checks both configured AprilTag trackers against
 // their expected camera-frame positions. Returns an error if any visible tag
-// is outside the configured tolerance. Returns nil if no trackers are
-// configured or if the expected position has not been set (all zeros).
-// getTagPosition returns the current camera-frame position of the AprilTag(s)
-// from both configured trackers. Useful for determining expected_tag_x/y/z config values.
+// getTagPosition returns the world-frame position of the center AprilTag as seen
+// by each configured tracker. Useful for verifying the cross-camera calibration check.
 func (vc *VinoCart) getTagPosition(ctx context.Context) (map[string]interface{}, error) {
 	result := map[string]interface{}{}
 
@@ -1446,8 +1461,13 @@ func (vc *VinoCart) getTagPosition(ctx context.Context) (map[string]interface{},
 			result[side+"_visible"] = false
 			return
 		}
-		pt := tagPose.Pose().Point()
 		result[side+"_visible"] = true
+		worldPose, err := vc.robotClient.TransformPose(ctx, tagPose, "world", nil)
+		if err != nil {
+			result[side+"_transform_error"] = err.Error()
+			return
+		}
+		pt := worldPose.Pose().Point()
 		result[side+"_tag_x"] = pt.X
 		result[side+"_tag_y"] = pt.Y
 		result[side+"_tag_z"] = pt.Z
@@ -1456,72 +1476,116 @@ func (vc *VinoCart) getTagPosition(ctx context.Context) (map[string]interface{},
 	queryTracker(vc.c.AprilTagTracker, vc.conf.AprilTagIDCenter, "right")
 	queryTracker(vc.c.AprilTagTrackerLeft, vc.conf.AprilTagIDCenter, "left")
 
+	if err := vc.checkAprilTagCalibration(ctx); err != nil {
+		result["calibration_ok"] = false
+		result["calibration_error"] = err.Error()
+	} else {
+		result["calibration_ok"] = true
+	}
+
 	return result, nil
 }
 
+
+// checkAprilTagCalibration checks that the left and right cameras agree on
+// the center AprilTag's world-frame position. If they disagree by more than
+// TagToleranceMM, at least one arm base has drifted. Skips silently if either
+// tracker is unconfigured or the tag is not visible to either camera.
 func (vc *VinoCart) checkAprilTagCalibration(ctx context.Context) error {
+	if vc.c.AprilTagTracker == nil || vc.c.AprilTagTrackerLeft == nil {
+		return nil
+	}
+
 	tagID := vc.conf.AprilTagIDCenter
 	if tagID == "" {
 		tagID = "0"
 	}
 
-	if vc.c.AprilTagTracker != nil {
-		expected := r3.Vector{X: vc.conf.ExpectedTagX, Y: vc.conf.ExpectedTagY, Z: vc.conf.ExpectedTagZ}
-		if err := vc.checkOneAprilTracker(ctx, vc.c.AprilTagTracker, tagID, expected, vc.conf.tagToleranceMM(), "right"); err != nil {
-			return err
-		}
-	}
-
-	if vc.c.AprilTagTrackerLeft != nil {
-		expected := r3.Vector{X: vc.conf.ExpectedTagXLeft, Y: vc.conf.ExpectedTagYLeft, Z: vc.conf.ExpectedTagZLeft}
-		if err := vc.checkOneAprilTracker(ctx, vc.c.AprilTagTrackerLeft, tagID, expected, vc.conf.tagToleranceMM(), "left"); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// checkOneAprilTracker checks a single tracker's tag position against the
-// expected camera-frame position. Skips silently if the tag is not visible
-// or if expected is all zeros (unconfigured).
-func (vc *VinoCart) checkOneAprilTracker(ctx context.Context, tracker posetracker.PoseTracker, tagID string, expected r3.Vector, toleranceMM float64, side string) error {
-	poses, err := tracker.Poses(ctx, nil, nil)
+	rightPoses, err := vc.c.AprilTagTracker.Poses(ctx, nil, nil)
 	if err != nil {
-		return fmt.Errorf("april tag (%s): failed to get poses: %w", side, err)
+		return fmt.Errorf("april tag (right): failed to get poses: %w", err)
 	}
-
-	tagPose, ok := poses[tagID]
+	rightTagPose, ok := rightPoses[tagID]
 	if !ok {
-		vc.logger.Infof("april tag %q (%s side) not visible, skipping calibration check", tagID, side)
+		vc.logger.Infof("april tag %q not visible from right camera, skipping calibration check", tagID)
 		return nil
 	}
 
-	if expected.X == 0 && expected.Y == 0 && expected.Z == 0 {
-		vc.logger.Debugf("april tag (%s side) expected position not configured, skipping check", side)
+	leftPoses, err := vc.c.AprilTagTrackerLeft.Poses(ctx, nil, nil)
+	if err != nil {
+		return fmt.Errorf("april tag (left): failed to get poses: %w", err)
+	}
+	leftTagPose, ok := leftPoses[tagID]
+	if !ok {
+		vc.logger.Infof("april tag %q not visible from left camera, skipping calibration check", tagID)
 		return nil
 	}
 
-	actual := tagPose.Pose().Point()
-	delta := r3.Vector{X: actual.X - expected.X, Y: actual.Y - expected.Y, Z: actual.Z - expected.Z}
+	rightWorld, err := vc.robotClient.TransformPose(ctx, rightTagPose, "world", nil)
+	if err != nil {
+		return fmt.Errorf("april tag (right): failed to transform to world frame: %w", err)
+	}
+	leftWorld, err := vc.robotClient.TransformPose(ctx, leftTagPose, "world", nil)
+	if err != nil {
+		return fmt.Errorf("april tag (left): failed to transform to world frame: %w", err)
+	}
+
+	rp := rightWorld.Pose().Point()
+	lp := leftWorld.Pose().Point()
+	delta := r3.Vector{X: rp.X - lp.X, Y: rp.Y - lp.Y, Z: rp.Z - lp.Z}
 	dist := math.Sqrt(delta.X*delta.X + delta.Y*delta.Y + delta.Z*delta.Z)
+	toleranceMM := vc.conf.tagToleranceMM()
 
-	vc.logger.Infof("april tag calibration (%s): actual=(%.1f, %.1f, %.1f) expected=(%.1f, %.1f, %.1f) dist=%.1fmm tolerance=%.1fmm",
-		side, actual.X, actual.Y, actual.Z, expected.X, expected.Y, expected.Z, dist, toleranceMM)
+	vc.logger.Infof("april tag calibration: right_world=(%.1f, %.1f, %.1f) left_world=(%.1f, %.1f, %.1f) dist=%.1fmm tolerance=%.1fmm",
+		rp.X, rp.Y, rp.Z, lp.X, lp.Y, lp.Z, dist, toleranceMM)
 
 	if dist > toleranceMM {
-		return fmt.Errorf("arm has drifted (%s side): tag is %.1fmm from expected position (tolerance %.1fmm) — please reposition the arm",
-			side, dist, toleranceMM)
+		return fmt.Errorf("arm positions disagree: left and right cameras see the tag %.1fmm apart in world frame (tolerance %.1fmm) — please reposition the arms",
+			dist, toleranceMM)
 	}
-	vc.logger.Infof("april tag calibration (%s): OK — dist=%.1fmm within tolerance=%.1fmm", side, dist, toleranceMM)
+	vc.logger.Infof("april tag calibration: OK — cameras agree within %.1fmm (tolerance %.1fmm)", dist, toleranceMM)
 	return nil
 }
 
 func (vc *VinoCart) FindCups(ctx context.Context) ([]*viz.Object, error) {
+	if vc.c.CupFinder == nil {
+		return nil, fmt.Errorf("cup_finder_service not configured")
+	}
 	objects, err := vc.c.CupFinder.GetObjectPointClouds(ctx, "", nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return FilterObjects(objects, vc.conf.CupHeight, vc.conf.cupWidth(), 25, vc.logger), nil
+	return FilterObjects(objects, vc.conf.CupHeight, vc.conf.cupWidth(), 15, "FindCups", vc.logger), nil
+}
+
+// GetCups finds the cups and returns them and their obstacles
+// requireCupToBePresent: if true, returns an error if no cups are found. This is useful for when we require a cup to be present such as picking it up.
+// allowMultiple: if true, returns multiple cups if found. This is useful for when we want to return all the cups found as obstacles to avoid.
+func (vc *VinoCart) GetCups(ctx context.Context, requireCupToBePresent bool, allowMultiple bool) ([]*viz.Object, []*referenceframe.GeometriesInFrame, error) {
+	start := time.Now()
+	objects, err := vc.FindCups(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	vc.logger.Infof("num cups: %v in %v", len(objects), time.Since(start))
+	for _, o := range objects {
+		vc.logger.Infof("\t cups: %v", o)
+	}
+
+	if len(objects) == 0 && requireCupToBePresent {
+		return nil, nil, noCupObjects
+	}
+
+	if len(objects) > 1 && !allowMultiple {
+		return nil, nil, fmt.Errorf("too many cups %d", len(objects))
+	}
+
+	obstacles := []*referenceframe.GeometriesInFrame{}
+	for i, o := range objects {
+		o.Geometry.SetLabel(fmt.Sprintf("cup-%d", i))
+		obstacles = append(obstacles, referenceframe.NewGeometriesInFrame("world", []spatialmath.Geometry{o.Geometry}))
+	}
+	return objects, obstacles, nil
 }

--- a/pour/vinocart.go
+++ b/pour/vinocart.go
@@ -8,8 +8,7 @@ import (
 	"image"
 	"image/png"
 	"io/fs"
-	"math"
-	"net/http"
+"net/http"
 	"os"
 	"runtime/debug"
 	"sync"
@@ -23,7 +22,6 @@ import (
 
 	"go.viam.com/rdk/app"
 	"go.viam.com/rdk/components/camera"
-	"go.viam.com/rdk/components/posetracker"
 	toggleswitch "go.viam.com/rdk/components/switch"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/motionplan/armplanning"
@@ -61,7 +59,7 @@ func newVinoCart(ctx context.Context, deps resource.Dependencies, conf resource.
 		return nil, err
 	}
 
-	c, err := Pour1ComponentsFromDependencies(config, deps)
+	c, err := Pour1ComponentsFromDependencies(config, deps, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -249,7 +247,7 @@ func (vc *VinoCart) DoCommand(ctx context.Context, cmd map[string]interface{}) (
 func (vc *VinoCart) run(ctx context.Context) {
 	defer vc.loopWaitGroup.Done()
 	for ctx.Err() == nil {
-		if err := vc.checkAprilTagCalibration(ctx); err != nil {
+		if err := vc.checkCalibration(ctx); err != nil {
 			vc.setStatusWithMessage("error", err.Error())
 			select {
 			case <-ctx.Done():
@@ -1432,110 +1430,32 @@ func moveWithLinearConstraint(ctx context.Context, m motion.Service, n resource.
 
 // checkAprilTagCalibration checks both configured AprilTag trackers against
 // their expected camera-frame positions. Returns an error if any visible tag
-// getTagPosition returns the world-frame position of the center AprilTag as seen
-// by each configured tracker. Useful for verifying the cross-camera calibration check.
+// getTagPosition delegates to the calibration sensor's Readings.
 func (vc *VinoCart) getTagPosition(ctx context.Context) (map[string]interface{}, error) {
-	result := map[string]interface{}{}
-
-	queryTracker := func(tracker posetracker.PoseTracker, tagID, side string) {
-		if tracker == nil {
-			return
-		}
-		if tagID == "" {
-			tagID = "0"
-		}
-		poses, err := tracker.Poses(ctx, nil, nil)
-		if err != nil {
-			result[side+"_error"] = err.Error()
-			return
-		}
-		tagPose, ok := poses[tagID]
-		if !ok {
-			result[side+"_visible"] = false
-			return
-		}
-		result[side+"_visible"] = true
-		worldPose, err := vc.robotClient.TransformPose(ctx, tagPose, "world", nil)
-		if err != nil {
-			result[side+"_transform_error"] = err.Error()
-			return
-		}
-		pt := worldPose.Pose().Point()
-		result[side+"_tag_x"] = pt.X
-		result[side+"_tag_y"] = pt.Y
-		result[side+"_tag_z"] = pt.Z
+	if vc.c.CalibrationSensor == nil {
+		return map[string]interface{}{"calibration_ok": true, "reason": "no calibration sensor configured"}, nil
 	}
-
-	queryTracker(vc.c.AprilTagTracker, vc.conf.AprilTagIDCenter, "right")
-	queryTracker(vc.c.AprilTagTrackerLeft, vc.conf.AprilTagIDCenter, "left")
-
-	if err := vc.checkAprilTagCalibration(ctx); err != nil {
-		result["calibration_ok"] = false
-		result["calibration_error"] = err.Error()
-	} else {
-		result["calibration_ok"] = true
-	}
-
-	return result, nil
+	return vc.c.CalibrationSensor.Readings(ctx, nil)
 }
 
-// checkAprilTagCalibration checks that the left and right cameras agree on
-// the center AprilTag's world-frame position. If they disagree by more than
-// TagToleranceMM, at least one arm base has drifted. Skips silently if either
-// tracker is unconfigured or the tag is not visible to either camera.
-func (vc *VinoCart) checkAprilTagCalibration(ctx context.Context) error {
-	if vc.c.AprilTagTracker == nil || vc.c.AprilTagTrackerLeft == nil {
+// checkCalibration reads from the calibration-checker sensor and returns
+// an error if calibration_ok is false.
+func (vc *VinoCart) checkCalibration(ctx context.Context) error {
+	if vc.c.CalibrationSensor == nil {
 		return nil
 	}
-
-	tagID := vc.conf.AprilTagIDCenter
-	if tagID == "" {
-		tagID = "0"
-	}
-
-	rightPoses, err := vc.c.AprilTagTracker.Poses(ctx, nil, nil)
+	readings, err := vc.c.CalibrationSensor.Readings(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("april tag (right): failed to get poses: %w", err)
+		return fmt.Errorf("calibration sensor error: %w", err)
 	}
-	rightTagPose, ok := rightPoses[tagID]
+	ok, _ := readings["calibration_ok"].(bool)
 	if !ok {
-		vc.logger.Infof("april tag %q not visible from right camera, skipping calibration check", tagID)
-		return nil
+		errMsg, _ := readings["error"].(string)
+		if errMsg == "" {
+			errMsg = "calibration check failed"
+		}
+		return fmt.Errorf("%s", errMsg)
 	}
-
-	leftPoses, err := vc.c.AprilTagTrackerLeft.Poses(ctx, nil, nil)
-	if err != nil {
-		return fmt.Errorf("april tag (left): failed to get poses: %w", err)
-	}
-	leftTagPose, ok := leftPoses[tagID]
-	if !ok {
-		vc.logger.Infof("april tag %q not visible from left camera, skipping calibration check", tagID)
-		return nil
-	}
-
-	rightWorld, err := vc.robotClient.TransformPose(ctx, rightTagPose, "world", nil)
-	if err != nil {
-		return fmt.Errorf("april tag (right): failed to transform to world frame: %w", err)
-	}
-	leftWorld, err := vc.robotClient.TransformPose(ctx, leftTagPose, "world", nil)
-	if err != nil {
-		return fmt.Errorf("april tag (left): failed to transform to world frame: %w", err)
-	}
-
-	rp := rightWorld.Pose().Point()
-	lp := leftWorld.Pose().Point()
-	delta := r3.Vector{X: rp.X - lp.X, Y: rp.Y - lp.Y, Z: rp.Z - lp.Z}
-	dist := math.Sqrt(delta.X*delta.X + delta.Y*delta.Y + delta.Z*delta.Z)
-	toleranceMM := vc.conf.tagToleranceMM()
-
-	vc.logger.Infof("april tag calibration: right_world=(%.1f, %.1f, %.1f) left_world=(%.1f, %.1f, %.1f) dist=%.1fmm tolerance=%.1fmm",
-		rp.X, rp.Y, rp.Z, lp.X, lp.Y, lp.Z, dist, toleranceMM)
-
-	if dist > toleranceMM {
-		return fmt.Errorf("arm positions disagree: left and right cameras see the tag %.1fmm apart in world frame (tolerance %.1fmm) — please reposition the arms",
-			dist, toleranceMM)
-	}
-	vc.logger.Infof("april tag calibration: OK — cameras agree within %.1fmm (tolerance %.1fmm)", dist, toleranceMM)
 	return nil
 }
 

--- a/pour/vinocart.go
+++ b/pour/vinocart.go
@@ -21,6 +21,7 @@ import (
 
 	"go.viam.com/rdk/app"
 	"go.viam.com/rdk/components/camera"
+	"go.viam.com/rdk/components/posetracker"
 	toggleswitch "go.viam.com/rdk/components/switch"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/motionplan/armplanning"
@@ -181,6 +182,10 @@ func (vc *VinoCart) DoCommand(ctx context.Context, cmd map[string]interface{}) (
 		return nil, multierr.Combine(vc.c.Arm.Stop(ctx, nil), vc.c.BottleArm.Stop(ctx, nil))
 	}
 
+	if cmd["get_tag_position"] == true {
+		return vc.getTagPosition(ctx)
+	}
+
 	if vc.loopCancel != nil {
 		return nil, fmt.Errorf("in loop mode, can't do anything but get status")
 	}
@@ -194,7 +199,7 @@ func (vc *VinoCart) DoCommand(ctx context.Context, cmd map[string]interface{}) (
 	}
 
 	if cmd["touch"] == true {
-		return nil, vc.Touch(ctx)
+		return nil, vc.TouchCup(ctx)
 	}
 
 	if cmd["pour-prep"] == true {
@@ -238,6 +243,16 @@ func (vc *VinoCart) DoCommand(ctx context.Context, cmd map[string]interface{}) (
 func (vc *VinoCart) run(ctx context.Context) {
 	defer vc.loopWaitGroup.Done()
 	for ctx.Err() == nil {
+		if err := vc.checkAprilTagCalibration(ctx); err != nil {
+			vc.setStatusWithMessage("error", err.Error())
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(2 * time.Second):
+			}
+			continue
+		}
+
 		vc.setStatus("standby")
 		err := vc.WaitForCupAndGo(ctx)
 		if err != nil {
@@ -293,7 +308,7 @@ func (vc *VinoCart) WaitForCupAndGo(ctx context.Context) error {
 }
 
 func (vc *VinoCart) FullDemo(ctx context.Context) error {
-	err := vc.Touch(ctx)
+	err := vc.TouchCup(ctx)
 	if err != nil {
 		return err
 	}
@@ -532,8 +547,13 @@ func saveImageToDataset(ctx context.Context, component resource.Name, img image.
 	return nil
 }
 
-func (vc *VinoCart) Touch(ctx context.Context) error {
-	vc.setStatus("looking")
+func (vc *VinoCart) TouchCup(ctx context.Context) error {
+	if err := vc.checkAprilTagCalibration(ctx); err != nil {
+		vc.setStatusWithMessage("error", err.Error())
+		return err
+	}
+
+	vc.setStatusWithMessage("looking", "Looking for cups")
 
 	err := vc.Reset(ctx)
 	if err != nil {
@@ -706,7 +726,7 @@ func (vc *VinoCart) handoffCupBottleToCupArm(ctx context.Context, worldState *re
 			return err
 		}
 
-		return vc.Touch(ctx)
+		return vc.TouchCup(ctx)
 	}
 	return fmt.Errorf("no path for handoff")
 }
@@ -1398,6 +1418,103 @@ func moveWithLinearConstraint(ctx context.Context, m motion.Service, n resource.
 		},
 	)
 	return err
+}
+
+// checkAprilTagCalibration checks both configured AprilTag trackers against
+// their expected camera-frame positions. Returns an error if any visible tag
+// is outside the configured tolerance. Returns nil if no trackers are
+// configured or if the expected position has not been set (all zeros).
+// getTagPosition returns the current camera-frame position of the AprilTag(s)
+// from both configured trackers. Useful for determining expected_tag_x/y/z config values.
+func (vc *VinoCart) getTagPosition(ctx context.Context) (map[string]interface{}, error) {
+	result := map[string]interface{}{}
+
+	queryTracker := func(tracker posetracker.PoseTracker, tagID, side string) {
+		if tracker == nil {
+			return
+		}
+		if tagID == "" {
+			tagID = "0"
+		}
+		poses, err := tracker.Poses(ctx, nil, nil)
+		if err != nil {
+			result[side+"_error"] = err.Error()
+			return
+		}
+		tagPose, ok := poses[tagID]
+		if !ok {
+			result[side+"_visible"] = false
+			return
+		}
+		pt := tagPose.Pose().Point()
+		result[side+"_visible"] = true
+		result[side+"_tag_x"] = pt.X
+		result[side+"_tag_y"] = pt.Y
+		result[side+"_tag_z"] = pt.Z
+	}
+
+	queryTracker(vc.c.AprilTagTracker, vc.conf.AprilTagIDCenter, "right")
+	queryTracker(vc.c.AprilTagTrackerLeft, vc.conf.AprilTagIDCenter, "left")
+
+	return result, nil
+}
+
+func (vc *VinoCart) checkAprilTagCalibration(ctx context.Context) error {
+	tagID := vc.conf.AprilTagIDCenter
+	if tagID == "" {
+		tagID = "0"
+	}
+
+	if vc.c.AprilTagTracker != nil {
+		expected := r3.Vector{X: vc.conf.ExpectedTagX, Y: vc.conf.ExpectedTagY, Z: vc.conf.ExpectedTagZ}
+		if err := vc.checkOneAprilTracker(ctx, vc.c.AprilTagTracker, tagID, expected, vc.conf.tagToleranceMM(), "right"); err != nil {
+			return err
+		}
+	}
+
+	if vc.c.AprilTagTrackerLeft != nil {
+		expected := r3.Vector{X: vc.conf.ExpectedTagXLeft, Y: vc.conf.ExpectedTagYLeft, Z: vc.conf.ExpectedTagZLeft}
+		if err := vc.checkOneAprilTracker(ctx, vc.c.AprilTagTrackerLeft, tagID, expected, vc.conf.tagToleranceMM(), "left"); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// checkOneAprilTracker checks a single tracker's tag position against the
+// expected camera-frame position. Skips silently if the tag is not visible
+// or if expected is all zeros (unconfigured).
+func (vc *VinoCart) checkOneAprilTracker(ctx context.Context, tracker posetracker.PoseTracker, tagID string, expected r3.Vector, toleranceMM float64, side string) error {
+	poses, err := tracker.Poses(ctx, nil, nil)
+	if err != nil {
+		return fmt.Errorf("april tag (%s): failed to get poses: %w", side, err)
+	}
+
+	tagPose, ok := poses[tagID]
+	if !ok {
+		vc.logger.Infof("april tag %q (%s side) not visible, skipping calibration check", tagID, side)
+		return nil
+	}
+
+	if expected.X == 0 && expected.Y == 0 && expected.Z == 0 {
+		vc.logger.Debugf("april tag (%s side) expected position not configured, skipping check", side)
+		return nil
+	}
+
+	actual := tagPose.Pose().Point()
+	delta := r3.Vector{X: actual.X - expected.X, Y: actual.Y - expected.Y, Z: actual.Z - expected.Z}
+	dist := math.Sqrt(delta.X*delta.X + delta.Y*delta.Y + delta.Z*delta.Z)
+
+	vc.logger.Infof("april tag calibration (%s): actual=(%.1f, %.1f, %.1f) expected=(%.1f, %.1f, %.1f) dist=%.1fmm tolerance=%.1fmm",
+		side, actual.X, actual.Y, actual.Z, expected.X, expected.Y, expected.Z, dist, toleranceMM)
+
+	if dist > toleranceMM {
+		return fmt.Errorf("arm has drifted (%s side): tag is %.1fmm from expected position (tolerance %.1fmm) — please reposition the arm",
+			side, dist, toleranceMM)
+	}
+	vc.logger.Infof("april tag calibration (%s): OK — dist=%.1fmm within tolerance=%.1fmm", side, dist, toleranceMM)
+	return nil
 }
 
 func (vc *VinoCart) FindCups(ctx context.Context) ([]*viz.Object, error) {

--- a/pour/vinocart.go
+++ b/pour/vinocart.go
@@ -97,7 +97,7 @@ func NewVinoCart(ctx context.Context, conf *Config, c *Pour1Components, client r
 	vc.cupTop = referenceframe.NewLinkInFrame(
 		vc.conf.GripperName,
 		spatialmath.NewPose(
-			r3.Vector{X: vc.conf.cupGripHeightOffset(), Y: -75, Z: -35},
+			r3.Vector{X: vc.conf.cupGripHeightOffset(), Y: -65, Z: -5},
 			&spatialmath.OrientationVectorDegrees{OX: 1},
 		),
 		cupTopName,

--- a/pour/vinocart.go
+++ b/pour/vinocart.go
@@ -45,6 +45,7 @@ var vinowebStaticFS embed.FS
 const bottleName = "bottle-top"
 const cupTopName = "cup-top"
 const gripperToCupCenterHack float64 = -35
+const cupGripHeightOffset float64 = 20
 
 var VinoCartModel = NamespaceFamily.WithModel("vinocart")
 var noObjects = fmt.Errorf("no objects")
@@ -97,7 +98,7 @@ func NewVinoCart(ctx context.Context, conf *Config, c *Pour1Components, client r
 	vc.cupTop = referenceframe.NewLinkInFrame(
 		vc.conf.GripperName,
 		spatialmath.NewPose(
-			r3.Vector{X: vc.conf.cupGripHeightOffset(), Y: -65, Z: -5},
+			r3.Vector{X: cupGripHeightOffset, Y: -65, Z: -5},
 			&spatialmath.OrientationVectorDegrees{OX: 1},
 		),
 		cupTopName,
@@ -743,7 +744,7 @@ func (vc *VinoCart) getApproachPoint(obj *viz.Object, deltaLinear float64, o *sp
 	c := md.Center()
 
 	p := touch.GetApproachPoint(c, deltaLinear, o)
-	p.Z = vc.conf.CupHeight - vc.conf.cupGripHeightOffset()
+	p.Z = vc.conf.CupHeight - cupGripHeightOffset
 
 	return referenceframe.NewPoseInFrame(
 		"world",
@@ -911,7 +912,7 @@ func (vc *VinoCart) moveToCurrentXYAtCupHeight(ctx context.Context) error {
 		spatialmath.NewPose(r3.Vector{
 			X: cur.Pose().Point().X,
 			Y: cur.Pose().Point().Y,
-			Z: vc.conf.CupHeight - vc.conf.cupGripHeightOffset(),
+			Z: vc.conf.CupHeight - cupGripHeightOffset,
 		}, cur.Pose().Orientation()))
 
 	_, err = vc.c.Motion.Move(

--- a/pour/vinocart.go
+++ b/pour/vinocart.go
@@ -49,8 +49,6 @@ const cupTopName = "cup-top"
 const gripperToCupCenterHack float64 = -35
 
 var VinoCartModel = NamespaceFamily.WithModel("vinocart")
-var noCupObjects = fmt.Errorf("no cup objects")
-var noBottleObjects = fmt.Errorf("no bottle objects")
 var noObjects = fmt.Errorf("no objects")
 
 func init() {
@@ -1558,33 +1556,3 @@ func (vc *VinoCart) FindCups(ctx context.Context) ([]*viz.Object, error) {
 	return FilterObjects(objects, vc.conf.CupHeight, vc.conf.cupWidth(), 15, "FindCups", vc.logger), nil
 }
 
-// GetCups finds the cups and returns them and their obstacles
-// requireCupToBePresent: if true, returns an error if no cups are found. This is useful for when we require a cup to be present such as picking it up.
-// allowMultiple: if true, returns multiple cups if found. This is useful for when we want to return all the cups found as obstacles to avoid.
-func (vc *VinoCart) GetCups(ctx context.Context, requireCupToBePresent bool, allowMultiple bool) ([]*viz.Object, []*referenceframe.GeometriesInFrame, error) {
-	start := time.Now()
-	objects, err := vc.FindCups(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	vc.logger.Infof("num cups: %v in %v", len(objects), time.Since(start))
-	for _, o := range objects {
-		vc.logger.Infof("\t cups: %v", o)
-	}
-
-	if len(objects) == 0 && requireCupToBePresent {
-		return nil, nil, noCupObjects
-	}
-
-	if len(objects) > 1 && !allowMultiple {
-		return nil, nil, fmt.Errorf("too many cups %d", len(objects))
-	}
-
-	obstacles := []*referenceframe.GeometriesInFrame{}
-	for i, o := range objects {
-		o.Geometry.SetLabel(fmt.Sprintf("cup-%d", i))
-		obstacles = append(obstacles, referenceframe.NewGeometriesInFrame("world", []spatialmath.Geometry{o.Geometry}))
-	}
-	return objects, obstacles, nil
-}

--- a/pour/vinoweb/src/RobotApp.svelte
+++ b/pour/vinoweb/src/RobotApp.svelte
@@ -6,6 +6,7 @@
   import { Struct, type JsonValue } from "@bufbuild/protobuf";
   import MainContent from "./lib/MainContent.svelte";
   import Status from "./lib/status.svelte";
+  import CalibrationWarning from "./lib/CalibrationWarning.svelte";
   import type { Joint } from "./lib/types.js";
 
   // --- Pouring status ---
@@ -158,6 +159,13 @@
 
 <div class="app-container">
   <aside class="sidebar"></aside>
+  <CalibrationWarning
+    show={robotStatus.status === "error"}
+    message={robotStatus.message}
+  />
+  {#if isDevMode}
+    <div id="dev-container">Dev mode</div>
+  {/if}
 
   <MainContent panes={panesData} {status}>
     {#snippet statusBar()}
@@ -168,6 +176,7 @@
 
 <style>
   .app-container {
+    position: relative;
     height: calc(100vh - 80px);
     width: 100%;
     max-width: 1920px;

--- a/pour/vinoweb/src/RobotApp.svelte
+++ b/pour/vinoweb/src/RobotApp.svelte
@@ -39,12 +39,18 @@
     error: "System error — check logs",
   };
 
+  let isDevMode = $state(false);
+
   // --- Keyboard controls for debugging ---
   function handleKeydown(event: KeyboardEvent) {
     const keys = Object.keys(statusMessages) as StatusKey[];
-    const keyNum = parseInt(event.key);
+    const key = event.key;
+    const keyNum = parseInt(key);
     if (keyNum >= 1 && keyNum <= keys.length) {
       robotStatus.status = keys[keyNum - 1];
+    }
+    if (key === "d") {
+      isDevMode = !isDevMode;
     }
   }
 

--- a/pour/vinoweb/src/RobotApp.svelte
+++ b/pour/vinoweb/src/RobotApp.svelte
@@ -18,8 +18,14 @@
     | "pouring"
     | "placing"
     | "waiting"
-    | "manual mode";
-  let status: StatusKey = $state("standby") as StatusKey;
+    | "manual mode"
+    | "error";
+
+  interface Status {
+    status: StatusKey;
+    message: string;
+  }
+  let robotStatus: Status = $state({ status: "standby", message: ''});
 
   const statusMessages: Record<StatusKey, string> = {
     standby: "Ready to pour!",
@@ -30,6 +36,7 @@
     placing: "Placing glass down",
     waiting: "Please enjoy!",
     "manual mode": "Manual mode active",
+    error: "System error — check logs",
   };
 
   // --- Keyboard controls for debugging ---
@@ -37,7 +44,7 @@
     const keys = Object.keys(statusMessages) as StatusKey[];
     const keyNum = parseInt(event.key);
     if (keyNum >= 1 && keyNum <= keys.length) {
-      status = keys[keyNum - 1];
+      robotStatus.status = keys[keyNum - 1];
     }
   }
 
@@ -107,16 +114,18 @@
           if (
             result &&
             typeof result === "object" &&
-            "status" in result &&
-            typeof (result as any).status === "string"
+            "status" in result && "message" in result &&
+            typeof (result as any).status === "string" &&
+            typeof (result as any).message === "string"
           ) {
-            const statusStr = (result as any).status;
+            const s = (result as any).status;
+            const message = (result as any).message;
             if (
               (Object.keys(statusMessages) as StatusKey[]).includes(
-                statusStr as StatusKey
+                s as StatusKey
               )
             ) {
-              status = statusStr as StatusKey;
+              robotStatus = { status: s, message };
             }
           }
         } catch (err) {
@@ -167,9 +176,9 @@
     <div id="dev-container">Dev mode</div>
   {/if}
 
-  <MainContent panes={panesData} {status}>
+  <MainContent panes={panesData} status={robotStatus.status}>
     {#snippet statusBar()}
-      <Status message={statusMessages[status]} />
+      <Status message={statusMessages[robotStatus.status]} />
     {/snippet}
   </MainContent>
 </div>

--- a/pour/vinoweb/src/lib/CalibrationWarning.svelte
+++ b/pour/vinoweb/src/lib/CalibrationWarning.svelte
@@ -7,18 +7,20 @@
   }: { show: boolean; message: string } = $props();
 
   let dismissed = $state(false);
-  let lastMessage = $state("");
+  let snoozed = $state(false);
+  let wasShowing = $state(false);
   let modalEl: HTMLDivElement | null = $state(null);
 
-  // Re-show if the error message changes (new calibration failure)
+  // Re-show (unless snoozed) only when the error clears and comes back
   $effect(() => {
-    if (message && message !== lastMessage) {
-      dismissed = false;
-      lastMessage = message;
+    if (show && !wasShowing) {
+      // error just appeared (or reappeared after recovering)
+      if (!snoozed) dismissed = false;
     }
+    wasShowing = show;
   });
 
-  const visible = $derived(show && !dismissed);
+  const visible = $derived(show && !dismissed && !snoozed);
 
   // Focus modal when it becomes visible so keyboard/screen readers work
   $effect(() => {
@@ -50,9 +52,14 @@
         {message || "April tag alignment check failed. Please reposition the arms."}
       </p>
       <p class="modal-hint">The robot will not operate until the arms are realigned.</p>
-      <button class="dismiss-btn" onclick={() => (dismissed = true)}>
-        Acknowledge &amp; Dismiss
-      </button>
+      <div class="btn-row">
+        <button class="snooze-btn" onclick={() => (snoozed = true)}>
+          Ignore for session
+        </button>
+        <button class="dismiss-btn" onclick={() => (dismissed = true)}>
+          Acknowledge &amp; Dismiss
+        </button>
+      </div>
     </div>
   </div>
 {/if}
@@ -118,19 +125,38 @@
     margin: 0 0 28px;
   }
 
-  .dismiss-btn {
-    background: #f1c21b;
-    color: #161616;
+  .btn-row {
+    display: flex;
+    gap: 12px;
+    justify-content: center;
+  }
+
+  .dismiss-btn,
+  .snooze-btn {
     border: none;
     border-radius: 6px;
-    padding: 10px 28px;
+    padding: 10px 24px;
     font-size: 0.925rem;
     font-weight: 600;
     cursor: pointer;
     transition: background 0.15s;
   }
 
+  .dismiss-btn {
+    background: #f1c21b;
+    color: #161616;
+  }
+
   .dismiss-btn:hover {
     background: #d2a106;
+  }
+
+  .snooze-btn {
+    background: #393939;
+    color: #c6c6c6;
+  }
+
+  .snooze-btn:hover {
+    background: #4c4c4c;
   }
 </style>

--- a/pour/vinoweb/src/lib/CalibrationWarning.svelte
+++ b/pour/vinoweb/src/lib/CalibrationWarning.svelte
@@ -1,0 +1,136 @@
+<script lang="ts">
+  import { tick } from "svelte";
+
+  let {
+    show = false,
+    message = "",
+  }: { show: boolean; message: string } = $props();
+
+  let dismissed = $state(false);
+  let lastMessage = $state("");
+  let modalEl: HTMLDivElement | null = $state(null);
+
+  // Re-show if the error message changes (new calibration failure)
+  $effect(() => {
+    if (message && message !== lastMessage) {
+      dismissed = false;
+      lastMessage = message;
+    }
+  });
+
+  const visible = $derived(show && !dismissed);
+
+  // Focus modal when it becomes visible so keyboard/screen readers work
+  $effect(() => {
+    if (visible && modalEl) {
+      tick().then(() => modalEl?.focus());
+    }
+  });
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape") dismissed = true;
+  }
+</script>
+
+{#if visible}
+  <div class="backdrop-wrap">
+    <button class="backdrop" onclick={() => (dismissed = true)} aria-label="Dismiss calibration warning"></button>
+    <div
+      class="modal"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="cal-title"
+      tabindex="-1"
+      bind:this={modalEl}
+      onkeydown={handleKeydown}
+    >
+      <div class="modal-icon">⚠</div>
+      <h2 id="cal-title">Calibration Warning</h2>
+      <p class="modal-message">
+        {message || "April tag alignment check failed. Please reposition the arms."}
+      </p>
+      <p class="modal-hint">The robot will not operate until the arms are realigned.</p>
+      <button class="dismiss-btn" onclick={() => (dismissed = true)}>
+        Acknowledge &amp; Dismiss
+      </button>
+    </div>
+  </div>
+{/if}
+
+<style>
+  /* Carbon warning: $support-warning = #f1c21b (yellow-30) */
+  .backdrop-wrap {
+    position: fixed;
+    inset: 0;
+    z-index: 200;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.82);
+    border: none;
+    cursor: default;
+  }
+
+  .modal {
+    position: relative;
+    z-index: 1;
+    background: #1c1c1c;
+    border: 1px solid #f1c21b;
+    border-radius: 12px;
+    padding: 40px 48px;
+    max-width: 520px;
+    width: 90%;
+    text-align: center;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+    transform: translateY(-1rem);
+    outline: none;
+  }
+
+  .modal-icon {
+    font-size: 2.5rem;
+    color: #f1c21b;
+    margin-bottom: 12px;
+    line-height: 1;
+  }
+
+  h2 {
+    color: #f4f4f4;
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin: 0 0 12px;
+  }
+
+  .modal-message {
+    color: #c6c6c6;
+    font-size: 0.925rem;
+    line-height: 1.5;
+    margin: 0 0 8px;
+  }
+
+  .modal-hint {
+    color: #6f6f6f;
+    font-size: 0.825rem;
+    margin: 0 0 28px;
+  }
+
+  .dismiss-btn {
+    background: #f1c21b;
+    color: #161616;
+    border: none;
+    border-radius: 6px;
+    padding: 10px 28px;
+    font-size: 0.925rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s;
+  }
+
+  .dismiss-btn:hover {
+    background: #d2a106;
+  }
+</style>

--- a/pour/vinoweb/src/lib/status.svelte
+++ b/pour/vinoweb/src/lib/status.svelte
@@ -33,6 +33,7 @@
     placing: { type: "teal", loading: true },
     waiting: { type: "green", icon: "checkmark--filled" },
     "manual mode": { type: "magenta", icon: "settings" },
+    error: { type: "red", icon: "warning--filled" },
   };
 
   $effect(() => {

--- a/pour/vision_cup_finder.go
+++ b/pour/vision_cup_finder.go
@@ -9,6 +9,7 @@ import (
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/services/vision"
+
 	//"go.viam.com/rdk/spatialmath"
 	viz "go.viam.com/rdk/vision"
 	"go.viam.com/rdk/vision/classification"

--- a/pour/vision_cup_finder.go
+++ b/pour/vision_cup_finder.go
@@ -142,7 +142,7 @@ func (vcf *visionCupFinder) DoCommand(ctx context.Context, extra map[string]inte
 	return nil, nil
 }
 
-func FilterObjects(objects []*viz.Object, correctHeight, correctWidth, goodDelta float64, logger logging.Logger) []*viz.Object {
+func FilterObjects(objects []*viz.Object, correctHeight, correctWidth, goodDelta float64, objectType string, logger logging.Logger) []*viz.Object {
 	good := []*viz.Object{}
 
 	for idx, o := range objects {
@@ -166,6 +166,8 @@ func FilterObjects(objects []*viz.Object, correctHeight, correctWidth, goodDelta
 		}
 
 		if heightDelta > goodDelta || widthDelta > goodDelta {
+			logger.Warnf("%s discarded object %d: height=%.2f (correct=%.2f) width=%.2f (correct=%.2f)",
+				objectType, idx, height, correctHeight, width, correctWidth)
 			continue
 		}
 


### PR DESCRIPTION
branched from #36

[PR for vmodutils](https://github.com/erh/vmodutils/pull/32)

Replaces the inline april tag calibration logic with a dependency on the erh:vmodutils:calibration-checker sensor. Config now takes a single `calibration_sensor` field instead of `april_tag_service_right/left`, `april_tag_id_center`, and `tag_tolerance_mm`.

Also makes optional deps (calibration sensor, glass pour tracker, cup finder) warn instead of hard-fail so the cart stays up when cameras go down.

### Config migration

1. Add the `erh:vmodutils` module to the machine (registry, `latest-with-prerelease`)
2. Add an `arm-calibration` sensor component:
   ```json
   {
     "name": "arm-calibration",
     "api": "rdk:component:sensor",
     "model": "erh:vmodutils:calibration-checker",
     "attributes": {
       "pose_trackers": ["april-tag-right", "april-tag-left"],
       "tag_id": "8",
       "tolerance_mm": 10
     }
   }
   ```
3. In the cart fragment mod, replace the old april tag fields with:
```
{ "$set": { "services.cart.attributes.calibration_sensor": "arm-calibration" } }
```
4. Remove any april_tag_service_right, april_tag_service_left, april_tag_id_center, tag_tolerance_mm mods.
5. Ensure loop: true is set on the cart service — calibration only runs in loop mode.