### PR TITLE
Upload bad motion plan files to Viam data management

### DIFF
--- a/cmd/tools/cmd-tools.go
+++ b/cmd/tools/cmd-tools.go
@@ -21,6 +21,99 @@ import (
 	"github.com/viam-modules/viam-pouring-demo/pour"
 )
 
+func getPlans(ctx context.Context, logger logging.Logger, partID, startStr, endStr string) error {
+	viamClient, err := app.ConnectFromCLIToken(ctx, logger)
+	if err != nil {
+		return fmt.Errorf("not logged in to Viam CLI (run `viam login`): %w", err)
+	}
+	defer viamClient.Close()
+	dataClient := viamClient.DataClient()
+
+	filter := &app.Filter{
+		PartID: partID,
+		TagsFilter: app.TagsFilter{
+			Type: app.TagsFilterTypeMatchByOr,
+			Tags: []string{"plan-file"},
+		},
+	}
+
+	if startStr != "" || endStr != "" {
+		var interval app.CaptureInterval
+		if startStr != "" {
+			t, err := time.Parse(time.RFC3339, startStr)
+			if err != nil {
+				return fmt.Errorf("invalid --start %q: %w", startStr, err)
+			}
+			interval.Start = t
+		}
+		if endStr != "" {
+			t, err := time.Parse(time.RFC3339, endStr)
+			if err != nil {
+				return fmt.Errorf("invalid --end %q: %w", endStr, err)
+			}
+			interval.End = t
+		}
+		filter.Interval = interval
+	}
+
+	// Phase 1: page through metadata only (includeBinary=false allows Limit>1).
+	var last string
+	var allIDs []string
+	var metaByID = map[string]*app.BinaryMetadata{}
+	for {
+		resp, err := dataClient.BinaryDataByFilter(ctx, false, &app.DataByFilterOptions{
+			Filter: filter,
+			Limit:  50,
+			Last:   last,
+		})
+		if err != nil {
+			return fmt.Errorf("querying data management: %w", err)
+		}
+		for _, d := range resp.BinaryData {
+			allIDs = append(allIDs, d.Metadata.BinaryDataID)
+			metaByID[d.Metadata.BinaryDataID] = d.Metadata
+		}
+		if len(resp.BinaryData) == 0 || resp.Last == "" {
+			break
+		}
+		last = resp.Last
+	}
+
+	// Phase 2: fetch binary content by ID.
+	total := 0
+	const batchSize = 10
+	for i := 0; i < len(allIDs); i += batchSize {
+		end := i + batchSize
+		if end > len(allIDs) {
+			end = len(allIDs)
+		}
+		batch := allIDs[i:end]
+		binaries, err := dataClient.BinaryDataByIDs(ctx, batch)
+		if err != nil {
+			return fmt.Errorf("fetching binary data: %w", err)
+		}
+		for _, d := range binaries {
+			meta := metaByID[d.Metadata.BinaryDataID]
+			fname := meta.FileName
+			if fname == "" {
+				fname = fmt.Sprintf("plan-%s.json", meta.BinaryDataID)
+			}
+			if err := os.WriteFile(fname, d.Binary, 0o600); err != nil {
+				logger.Errorf("failed to write %s: %v", fname, err)
+				continue
+			}
+			logger.Infof("saved %s (captured: %s, tags: %v)",
+				fname,
+				meta.TimeRequested.Format(time.RFC3339),
+				meta.CaptureMetadata.Tags,
+			)
+			total++
+		}
+	}
+	logger.Infof("downloaded %d plan file(s)", total)
+	return nil
+}
+
 func main() {
 	err := realMain()
 	if err != nil {
@@ -39,11 +132,22 @@ func realMain() error {
 	flag.IntVar(&n, "n", n, "number of times to run")
 	host := flag.String("host", "", "host to connect to")
 	configFile := flag.String("config", "", "host to connect to")
+	partID := flag.String("part-id", "", "machine part ID to query plan files from data management")
+	startStr := flag.String("start", "", "start time filter for get-plans (RFC3339, e.g. 2026-04-23T10:00:00Z)")
+	endStr := flag.String("end", "", "end time filter for get-plans (RFC3339)")
 
 	flag.Parse()
 
 	if debug {
 		logger.SetLevel(logging.DEBUG)
+	}
+
+	// get-plans only needs a cloud client, not a robot connection
+	if flag.Arg(0) == "get-plans" {
+		if *partID == "" {
+			return fmt.Errorf("--part-id is required for get-plans")
+		}
+		return getPlans(ctx, logger, *partID, *startStr, *endStr)
 	}
 
 	if *configFile == "" {

--- a/pour/vinocart.go
+++ b/pour/vinocart.go
@@ -531,6 +531,39 @@ func saveImageToDataset(ctx context.Context, component resource.Name, img image.
 	return nil
 }
 
+// uploadPlanFile uploads a serialized PlanRequest to Viam data management as a .json file.
+// It is best-effort: errors are logged and do not affect the caller's error flow.
+// tag is added as a data management tag alongside "plan-file" (e.g. "align-plan-bad").
+func (vc *VinoCart) uploadPlanFile(tag, filename string, req *armplanning.PlanRequest) {
+	if vc.dataClient == nil {
+		return
+	}
+	pid := os.Getenv("VIAM_MACHINE_PART_ID")
+	if pid == "" {
+		vc.logger.Warn("VIAM_MACHINE_PART_ID not set, skipping plan file upload")
+		return
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		vc.logger.Errorf("failed to marshal plan for upload (%s): %v", filename, err)
+		return
+	}
+	ext := ".json"
+	opts := &app.FileUploadOptions{
+		FileName:      &filename,
+		FileExtension: &ext,
+		Tags:          []string{"plan-file", tag},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	id, err := vc.dataClient.FileUploadFromBytes(ctx, pid, data, opts)
+	if err != nil {
+		vc.logger.Errorf("failed to upload plan file %s: %v", filename, err)
+		return
+	}
+	vc.logger.Infof("uploaded plan file %s to data management (id: %s)", filename, id)
+}
+
 func (vc *VinoCart) Touch(ctx context.Context) error {
 	vc.setStatus("looking")
 
@@ -1048,6 +1081,8 @@ func (vc *VinoCart) Pour(ctx context.Context) error {
 			} else {
 				vc.logger.Warnf("[bottle-to-cup-align][try %d] debug written to %s", try, fn)
 			}
+			vc.uploadPlanFile("align-plan-bad",
+				fmt.Sprintf("align-plan-bad-try-%d-%d.json", try, time.Now().Unix()), alignReq)
 			lastErr = fmt.Errorf("[bottle-to-cup-align][try %d] pos too far: %v", try, alignL2)
 			// On all but the final try, replan 
 			if try < maxAlignTries {
@@ -1364,6 +1399,8 @@ func (vc *VinoCart) SetupPourPositions(ctx context.Context) (*PourPositions, err
 				if writeErr := req.WriteToFile(fn); writeErr != nil {
 					vc.logger.Errorf("failed to write pour debug: %v", writeErr)
 				}
+				vc.uploadPlanFile("pour-plan-bad",
+					fmt.Sprintf("pour-plan-bad-%d.json", time.Now().Unix()), req)
 				return nil, fmt.Errorf("pourPlan pos too far %v, written to: %s", d, fn)
 			}
 		}


### PR DESCRIPTION
## Summary

Automatically uploads bad motion plan files to Viam data management when alignment or pour-tilt planning fails, replacing the previous manual SCP workflow. Adds a `get-plans` CLI command to retrieve them by part ID and optional time range.

## Changes

### `pour/vinocart.go`
- Added `uploadPlanFile(tag, filename string, req *armplanning.PlanRequest)` helper — marshals the plan request to JSON and uploads via `FileUploadFromBytes` with tags `["plan-file", <tag>]`
- Calls `uploadPlanFile("align-plan-bad", ...)` on bad align plans in `Pour()`
- Calls `uploadPlanFile("pour-plan-bad", ...)` on bad pour-tilt plans in `SetupPourPositions()`
- Upload is best-effort: errors are logged and do not affect the motion failure path
- Requires `VIAM_MACHINE_PART_ID` env var (set automatically by the Viam module platform)

### `cmd/tools/cmd-tools.go`
- Added `--part-id`, `--start`, `--end` flags
- Added `get-plans` command that connects via `viam login` CLI token (no robot connection needed)
- Fetches plan files using a two-phase approach:
  1. Page metadata with `includeBinary=false, limit=50` (API requires limit=1 when `includeBinary=true`)
  2. Fetch binary content in batches via `BinaryDataByIDs`
- Saves files to the current directory, named by original filename or `plan-<id>.json`

## Usage

```bash
# Retrieve all bad plan files for a machine
go run ./cmd/tools/cmd-tools.go --part-id <part-id> get-plans

# Filter by time range
go run ./cmd/tools/cmd-tools.go --part-id <part-id> --start 2026-04-20T00:00:00Z get-plans

## Testing
- Builds and vets clean
- `get-plans` verified end-to-end with real auth; upload path to be tested on robot