### PR TITLE
Manual Data Capture

### DIFF
--- a/cmd/vla/capture_direct.go
+++ b/cmd/vla/capture_direct.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"go.viam.com/rdk/components/arm"
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/referenceframe"
@@ -17,6 +18,7 @@ import (
 
 type captureDirectOptions struct {
 	outDir      string
+	armName     string
 	gripperName string
 	camNames    []string
 	instruction string
@@ -24,8 +26,9 @@ type captureDirectOptions struct {
 }
 
 type poseSample struct {
-	t  time.Time
-	ee []float64
+	t      time.Time
+	ee     []float64
+	joints []float64
 }
 
 type camSample struct {
@@ -37,6 +40,15 @@ type camSample struct {
 func runCaptureDirect(ctx context.Context, client robot.Robot, opts captureDirectOptions, logger logging.Logger) error {
 	if opts.hz <= 0 {
 		return fmt.Errorf("-hz must be positive, got %d", opts.hz)
+	}
+
+	var armComp arm.Arm
+	if opts.armName != "" {
+		a, err := arm.FromRobot(client, opts.armName)
+		if err != nil {
+			return fmt.Errorf("arm %q: %w", opts.armName, err)
+		}
+		armComp = a
 	}
 
 	var camComps []camera.Camera
@@ -89,8 +101,19 @@ func runCaptureDirect(ctx context.Context, client robot.Robot, opts captureDirec
 					worldPose.Point().X, worldPose.Point().Y, worldPose.Point().Z,
 					ovd.OX, ovd.OY, ovd.OZ, ovd.Theta,
 				}
+
+				var joints []float64
+				if armComp != nil {
+					jp, jerr := armComp.JointPositions(ctx, nil)
+					if jerr != nil {
+						logger.Warnf("arm JointPositions err: %v", jerr)
+					} else {
+						joints = jp
+					}
+				}
+
 				muPose.Lock()
-				poseSamples = append(poseSamples, poseSample{t: t, ee: ee})
+				poseSamples = append(poseSamples, poseSample{t: t, ee: ee, joints: joints})
 				muPose.Unlock()
 			}
 		}
@@ -167,8 +190,10 @@ func writeOpenVLAEpisode(epDir string, cam []camSample, numCams int, poses []pos
 
 	for i, c := range primary {
 		var ee []float64
+		var joints []float64
 		if p := closestPose(poses, c.t); p != nil {
 			ee = p.ee
+			joints = p.joints
 		}
 
 		step := map[string]any{
@@ -179,6 +204,7 @@ func writeOpenVLAEpisode(epDir string, cam []camSample, numCams int, poses []pos
 			"is_terminal":          i == len(primary)-1,
 			"image":                c.rel,
 			"ee_pose":              ee,
+			"joint_positions":      joints,
 			"language_instruction": instruction,
 		}
 

--- a/cmd/vla/capture_direct.go
+++ b/cmd/vla/capture_direct.go
@@ -12,14 +12,13 @@ import (
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/referenceframe"
-	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/robot"
 )
 
 type captureDirectOptions struct {
 	outDir      string
 	gripperName string
-	camName     string
+	camNames    []string
 	instruction string
 	hz          int
 }
@@ -30,25 +29,32 @@ type poseSample struct {
 }
 
 type camSample struct {
-	t   time.Time
-	rel string
+	t      time.Time
+	rel    string
+	camIdx int
 }
 
-func runCaptureDirect(ctx context.Context, client robot.Robot, vc resource.Resource, opts captureDirectOptions, logger logging.Logger) error {
+func runCaptureDirect(ctx context.Context, client robot.Robot, opts captureDirectOptions, logger logging.Logger) error {
 	if opts.hz <= 0 {
 		return fmt.Errorf("-hz must be positive, got %d", opts.hz)
 	}
 
-	camComp, err := camera.FromRobot(client, opts.camName)
-	if err != nil {
-		return err
+	var camComps []camera.Camera
+	for _, name := range opts.camNames {
+		c, err := camera.FromRobot(client, name)
+		if err != nil {
+			return fmt.Errorf("camera %q: %w", name, err)
+		}
+		camComps = append(camComps, c)
 	}
 
 	sessionID := time.Now().UTC().Format("20060102T150405.000Z")
 	epDir := filepath.Join(opts.outDir, sessionID)
-	imgDir := filepath.Join(epDir, "images")
-	if err := os.MkdirAll(imgDir, 0o755); err != nil {
-		return err
+	for i := range camComps {
+		imgDir := filepath.Join(epDir, fmt.Sprintf("images_%d", i))
+		if err := os.MkdirAll(imgDir, 0o755); err != nil {
+			return err
+		}
 	}
 
 	period := time.Second / time.Duration(opts.hz)
@@ -90,67 +96,66 @@ func runCaptureDirect(ctx context.Context, client robot.Robot, vc resource.Resou
 		}
 	}()
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		ticker := time.NewTicker(period)
-		defer ticker.Stop()
-		idx := 0
-		for {
-			select {
-			case <-captureCtx.Done():
-				return
-			case <-ticker.C:
-				t := time.Now()
-				imgs, _, err := camComp.Images(ctx, nil, nil)
-				if err != nil || len(imgs) == 0 {
-					logger.Debugf("cam read err: %v (n=%d)", err, len(imgs))
-					continue
+	for camIdx, camComp := range camComps {
+		wg.Add(1)
+		go func(camIdx int, camComp camera.Camera) {
+			defer wg.Done()
+			ticker := time.NewTicker(period)
+			defer ticker.Stop()
+			idx := 0
+			for {
+				select {
+				case <-captureCtx.Done():
+					return
+				case <-ticker.C:
+					t := time.Now()
+					imgs, _, err := camComp.Images(ctx, nil, nil)
+					if err != nil || len(imgs) == 0 {
+						logger.Debugf("cam[%d] read err: %v (n=%d)", camIdx, err, len(imgs))
+						continue
+					}
+					bs, err := imgs[0].Bytes(ctx)
+					if err != nil {
+						logger.Warnf("cam[%d] bytes err: %v", camIdx, err)
+						continue
+					}
+					ext := mimeExt(imgs[0].MimeType())
+					rel := filepath.Join(fmt.Sprintf("images_%d", camIdx), fmt.Sprintf("step_%06d%s", idx, ext))
+					if err := os.WriteFile(filepath.Join(epDir, rel), bs, 0o644); err != nil {
+						logger.Debugf("write img: %v", err)
+						continue
+					}
+					idx++
+					muCam.Lock()
+					camSamples = append(camSamples, camSample{t: t, rel: rel, camIdx: camIdx})
+					muCam.Unlock()
 				}
-				bs, err := imgs[0].Bytes(ctx)
-				if err != nil {
-					logger.Warnf("cam bytes err: %v", err)
-					continue
-				}
-				ext := mimeExt(imgs[0].MimeType())
-				rel := filepath.Join("images", fmt.Sprintf("step_%06d%s", idx, ext))
-				if err := os.WriteFile(filepath.Join(epDir, rel), bs, 0o644); err != nil {
-					logger.Debugf("write img: %v", err)
-					continue
-				}
-				idx++
-				muCam.Lock()
-				camSamples = append(camSamples, camSample{t: t, rel: rel})
-				muCam.Unlock()
 			}
-		}
-	}()
+		}(camIdx, camComp)
+	}
 
 	logger.Infof("capture-direct: started gripper-pose + cam goroutines @ %dHz, episode dir %s", opts.hz, epDir)
-	_, touchErr := vc.DoCommand(ctx, map[string]any{"touch": true})
+	fmt.Println("Recording... press Enter to stop.")
+	fmt.Scanln()
 	stopCapture()
 	wg.Wait()
 
-	if touchErr != nil {
-		logger.Warnf("touch failed (%v); removing %s", touchErr, epDir)
-		_ = os.RemoveAll(epDir)
-		return touchErr
-	}
-
 	logger.Infof("captured %d pose samples, %d cam samples", len(poseSamples), len(camSamples))
-	if err := writeOpenVLAEpisode(epDir, camSamples, poseSamples, opts.instruction); err != nil {
+	if err := writeOpenVLAEpisode(epDir, camSamples, len(camComps), poseSamples, opts.instruction); err != nil {
 		return fmt.Errorf("writing episode: %w", err)
-	}
-
-	if _, err := vc.DoCommand(ctx, map[string]any{"reset": true}); err != nil {
-		return err
 	}
 	return nil
 }
 
-func writeOpenVLAEpisode(epDir string, cam []camSample, poses []poseSample, instruction string) error {
-	if len(cam) == 0 {
-		return fmt.Errorf("no camera samples")
+func writeOpenVLAEpisode(epDir string, cam []camSample, numCams int, poses []poseSample, instruction string) error {
+	// Split samples by camera index. Camera 0 is the primary timeline.
+	perCam := make([][]camSample, numCams)
+	for _, c := range cam {
+		perCam[c.camIdx] = append(perCam[c.camIdx], c)
+	}
+	primary := perCam[0]
+	if len(primary) == 0 {
+		return fmt.Errorf("no camera samples from primary camera")
 	}
 
 	f, err := os.Create(filepath.Join(epDir, "steps.jsonl"))
@@ -160,7 +165,7 @@ func writeOpenVLAEpisode(epDir string, cam []camSample, poses []poseSample, inst
 	defer f.Close()
 	enc := json.NewEncoder(f)
 
-	for i, c := range cam {
+	for i, c := range primary {
 		var ee []float64
 		if p := closestPose(poses, c.t); p != nil {
 			ee = p.ee
@@ -170,17 +175,41 @@ func writeOpenVLAEpisode(epDir string, cam []camSample, poses []poseSample, inst
 			"step_index":           i,
 			"timestamp":            c.t.UTC().Format(time.RFC3339Nano),
 			"is_first":             i == 0,
-			"is_last":              i == len(cam)-1,
-			"is_terminal":          i == len(cam)-1,
+			"is_last":              i == len(primary)-1,
+			"is_terminal":          i == len(primary)-1,
 			"image":                c.rel,
 			"ee_pose":              ee,
 			"language_instruction": instruction,
 		}
+
+		for camIdx := 1; camIdx < numCams; camIdx++ {
+			key := fmt.Sprintf("image_%d", camIdx)
+			if closest := closestCam(perCam[camIdx], c.t); closest != nil {
+				step[key] = closest.rel
+			}
+		}
+
 		if err := enc.Encode(step); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func closestCam(rows []camSample, t time.Time) *camSample {
+	if len(rows) == 0 {
+		return nil
+	}
+	best := &rows[0]
+	bestD := absDur(rows[0].t.Sub(t))
+	for i := 1; i < len(rows); i++ {
+		d := absDur(rows[i].t.Sub(t))
+		if d < bestD {
+			best = &rows[i]
+			bestD = d
+		}
+	}
+	return best
 }
 
 func closestPose(rows []poseSample, t time.Time) *poseSample {

--- a/cmd/vla/capture_direct.go
+++ b/cmd/vla/capture_direct.go
@@ -11,6 +11,7 @@ import (
 
 	"go.viam.com/rdk/components/arm"
 	"go.viam.com/rdk/components/camera"
+	"go.viam.com/rdk/components/gripper"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/robot"
@@ -26,9 +27,11 @@ type captureDirectOptions struct {
 }
 
 type poseSample struct {
-	t      time.Time
-	ee     []float64
-	joints []float64
+	t          time.Time
+	ee         []float64
+	joints     []float64
+	gripperPos int
+	isHolding  bool
 }
 
 type camSample struct {
@@ -49,6 +52,11 @@ func runCaptureDirect(ctx context.Context, client robot.Robot, opts captureDirec
 			return fmt.Errorf("arm %q: %w", opts.armName, err)
 		}
 		armComp = a
+	}
+
+	gripComp, err := gripper.FromRobot(client, opts.gripperName)
+	if err != nil {
+		return fmt.Errorf("gripper %q: %w", opts.gripperName, err)
 	}
 
 	var camComps []camera.Camera
@@ -112,8 +120,35 @@ func runCaptureDirect(ctx context.Context, client robot.Robot, opts captureDirec
 					}
 				}
 
+				var gripperPos int
+				var isHolding bool
+				holding, gerr := gripComp.IsHoldingSomething(ctx, nil)
+				if gerr != nil {
+					logger.Warnf("gripper IsHoldingSomething err: %v", gerr)
+				} else {
+					isHolding = holding.IsHoldingSomething
+					if posRaw, ok := holding.Meta["position"]; ok {
+						switch v := posRaw.(type) {
+						case float64:
+							gripperPos = int(v)
+						case int:
+							gripperPos = v
+						default:
+							logger.Warnf("gripper position has unexpected type %T: %v", posRaw, posRaw)
+						}
+					} else {
+						logger.Warnf("gripper IsHoldingSomething returned no position in Meta: %v", holding.Meta)
+					}
+				}
+
 				muPose.Lock()
-				poseSamples = append(poseSamples, poseSample{t: t, ee: ee, joints: joints})
+				poseSamples = append(poseSamples, poseSample{
+					t:          t,
+					ee:         ee,
+					joints:     joints,
+					gripperPos: gripperPos,
+					isHolding:  isHolding,
+				})
 				muPose.Unlock()
 			}
 		}
@@ -191,9 +226,13 @@ func writeOpenVLAEpisode(epDir string, cam []camSample, numCams int, poses []pos
 	for i, c := range primary {
 		var ee []float64
 		var joints []float64
+		var gripperPos int
+		var isHolding bool
 		if p := closestPose(poses, c.t); p != nil {
 			ee = p.ee
 			joints = p.joints
+			gripperPos = p.gripperPos
+			isHolding = p.isHolding
 		}
 
 		step := map[string]any{
@@ -205,6 +244,8 @@ func writeOpenVLAEpisode(epDir string, cam []camSample, numCams int, poses []pos
 			"image":                c.rel,
 			"ee_pose":              ee,
 			"joint_positions":      joints,
+			"gripper_position":     gripperPos,
+			"is_holding":           isHolding,
 			"language_instruction": instruction,
 		}
 

--- a/cmd/vla/vino-vla-cmd.go
+++ b/cmd/vla/vino-vla-cmd.go
@@ -33,7 +33,7 @@ func realMain() error {
 
 	since := flag.Duration("since", 24*time.Hour, "export: only include sessions started within this window (0 = all)")
 	outDir := flag.String("out", "openvla-export", "output directory (export and capture-direct)")
-	armName := flag.String("arm", "left-arm", "arm component name (export only, for JointPositions data)")
+	armName := flag.String("arm", "left-arm", "arm component name (for JointPositions data)")
 	gripperName := flag.String("gripper", "left-gripper", "gripper component name (capture-direct: frame system → world pose)")
 	camName := flag.String("cam", "right-cam", "primary camera component name")
 	cam2Name := flag.String("cam2", "", "second camera component name (optional)")
@@ -127,6 +127,7 @@ func realMain() error {
 
 		return runCaptureDirect(ctx, client, captureDirectOptions{
 			outDir:      *outDir,
+			armName:     *armName,
 			gripperName: *gripperName,
 			camNames:    camNames,
 			instruction: *instruction,

--- a/cmd/vla/vino-vla-cmd.go
+++ b/cmd/vla/vino-vla-cmd.go
@@ -14,7 +14,6 @@ import (
 	"go.viam.com/rdk/app"
 	"go.viam.com/rdk/components/sensor"
 	"go.viam.com/rdk/logging"
-	"go.viam.com/rdk/services/generic"
 )
 
 func main() {
@@ -31,13 +30,14 @@ func realMain() error {
 	debug := false
 	flag.BoolVar(&debug, "debug", false, "")
 	host := flag.String("host", "", "host to connect to (also drives sessions-<host>.csv path)")
-	cartName := flag.String("cart", "cart", "name of the vinocart generic service")
 
 	since := flag.Duration("since", 24*time.Hour, "export: only include sessions started within this window (0 = all)")
 	outDir := flag.String("out", "openvla-export", "output directory (export and capture-direct)")
 	armName := flag.String("arm", "left-arm", "arm component name (export only, for JointPositions data)")
 	gripperName := flag.String("gripper", "left-gripper", "gripper component name (capture-direct: frame system → world pose)")
-	camName := flag.String("cam", "right-cam", "camera component name")
+	camName := flag.String("cam", "right-cam", "primary camera component name")
+	cam2Name := flag.String("cam2", "", "second camera component name (optional)")
+	cam3Name := flag.String("cam3", "", "third camera component name (optional)")
 	instruction := flag.String("instruction", "grab the cup", "language instruction")
 	hz := flag.Int("hz", 10, "capture-direct: sample rate (Hz) for arm and camera")
 
@@ -62,10 +62,10 @@ func realMain() error {
 		}
 		defer client.Close(ctx)
 
-		vc, err := generic.FromRobot(client, *cartName)
-		if err != nil {
-			return err
-		}
+		// vc, err := generic.FromRobot(client, *cartName)
+		// if err != nil {
+		// 	return err
+		// }
 
 		capture, err := sensor.FromRobot(client, "touch-session-capture")
 		if err != nil {
@@ -85,44 +85,50 @@ func realMain() error {
 		time.Sleep(5 * time.Second)
 
 		startTS := time.Now()
-		_, touchErr := vc.DoCommand(ctx, map[string]any{"touch": true})
+		// _, touchErr := vc.DoCommand(ctx, map[string]any{"touch": true})
 		endTS := time.Now()
 
-		if _, err := capture.DoCommand(ctx, map[string]any{"stop": true}); err != nil {
-			if touchErr != nil {
-				return fmt.Errorf("touch failed: %v; also failed to stop capture: %w", touchErr, err)
-			}
-			return err
-		}
+		// if _, err := capture.DoCommand(ctx, map[string]any{"stop": true}); err != nil {
+		// 	if touchErr != nil {
+		// 		return fmt.Errorf("touch failed: %v; also failed to stop capture: %w", touchErr, err)
+		// 	}
+		// 	return err
+		// }
 
-		if touchErr != nil {
-			return touchErr
-		}
+		// if touchErr != nil {
+		// 	return touchErr
+		// }
 
 		if err := appendSession(sessionsPath, startTS, endTS); err != nil {
 			return fmt.Errorf("recording session: %w", err)
 		}
 		logger.Infof("recorded session [%s, %s] to %s", startTS.Format(time.RFC3339Nano), endTS.Format(time.RFC3339Nano), sessionsPath)
 
-		_, err = vc.DoCommand(ctx, map[string]any{"reset": true})
+		// _, err = vc.DoCommand(ctx, map[string]any{"reset": true})
 		return err
 
-	case "capture-direct": // this is temporary until sequences and related are finished 
-		client, err := vmodutils.ConnectToHostFromCLIToken(ctx, *host, logger)
+	case "capture-direct":
+		connectCtx, connectCancel := context.WithTimeout(ctx, 15*time.Second)
+		defer connectCancel()
+		logger.Infof("connecting to %s...", *host)
+		client, err := vmodutils.ConnectToHostFromCLIToken(connectCtx, *host, logger)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to connect to %s: %w", *host, err)
 		}
 		defer client.Close(ctx)
 
-		vc, err := generic.FromRobot(client, *cartName)
-		if err != nil {
-			return err
+		camNames := []string{*camName}
+		if *cam2Name != "" {
+			camNames = append(camNames, *cam2Name)
+		}
+		if *cam3Name != "" {
+			camNames = append(camNames, *cam3Name)
 		}
 
-		return runCaptureDirect(ctx, client, vc, captureDirectOptions{
+		return runCaptureDirect(ctx, client, captureDirectOptions{
 			outDir:      *outDir,
 			gripperName: *gripperName,
-			camName:     *camName,
+			camNames:    camNames,
 			instruction: *instruction,
 			hz:          *hz,
 		}, logger)


### PR DESCRIPTION
Manual data capture for training VLA policies.

## What it does

`capture-direct` records synchronized robot telemetry + camera images at a configurable Hz, producing JSONL episodes suitable for VLA fine-tuning.

### Per-step data captured
- **EE pose** (7-DoF): `[x, y, z, ox, oy, oz, theta]` via frame system
- **Joint positions**: raw joint angles from the arm component
- **Gripper position**: continuous xArm gripper value (0–840) plus an `is_holding` bool
- **Images**: up to 3 cameras, time-aligned to the primary camera timeline
- **Language instruction**: task description string

### Example usage
```
go run ./cmd/vla \
    -host arm-teleop-demo-main.kssbd6djf3.viam.cloud \
    -arm left-arm \
    -gripper right-gripper \
    -cam right-cam \
    -cam2 left-cam \
    -cam3 HDWebcameMeetC950HDWebcamusb000000140422-0 \
    -instruction "grab the black block and put it in the blue bowl" \
    -hz 50 \
    capture-direct
```

### Output format
```
openvla-export/<session_id>/
├── steps.jsonl          # {ee_pose, joint_positions, gripper_position, is_holding, image paths, instruction, ...}
├── images_0/            # primary camera
├── images_1/            # secondary camera (optional)
└── images_2/            # tertiary camera (optional)
```

Not meant to be merged, for temporary manual data capture.