### PR TITLE
VLA training and inference scripts

### DIFF
--- a/cmd/vla/convert_to_lerobot.py
+++ b/cmd/vla/convert_to_lerobot.py
@@ -1,0 +1,296 @@
+"""Convert capture-direct `steps.jsonl` episodes to LeRobot v2 dataset format.
+
+Input layout (produced by `vla capture-direct`):
+  <data-root>/<session_id>/
+    steps.jsonl                # one JSON per line
+    images_0/step_NNNNNN.jpg   # primary camera
+    images_1/step_NNNNNN.jpg   # optional second camera
+    images_2/step_NNNNNN.jpg   # optional third camera
+
+Each step (current schema):
+  {
+    "step_index": int,
+    "timestamp": ISO8601,
+    "is_first": bool, "is_last": bool, "is_terminal": bool,
+    "image":   "images_0/step_NNNNNN.jpg",
+    "image_1": "images_1/step_NNNNNN.jpg",     # optional
+    "image_2": "images_2/step_NNNNNN.jpg",     # optional
+    "ee_pose": [x, y, z, ox, oy, oz, theta_deg],
+    "joint_positions": [j0..j5],
+    "gripper_position": int (0..840),
+    "is_holding": bool,
+    "language_instruction": str,
+  }
+
+Output (LeRobot v2.0):
+  <output-dir>/
+    meta/info.json
+    meta/episodes.jsonl
+    meta/tasks.jsonl
+    meta/stats.json
+    data/chunk-000/episode_000000.parquet
+    ...
+
+State / action representation:
+  observation.state = [j0..j5, gripper_norm]                      (7-D float32)
+  action            = state at next step (absolute target)        (7-D float32)
+  gripper_norm      = gripper_position / 840.0  (in [0, 1])
+  Terminal frames use action = current state (no movement).
+
+Camera features are stored as JPEG-encoded `image` features in the parquet.
+"""
+
+import argparse
+import io
+import json
+import logging
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+from PIL import Image
+
+GRIPPER_RAW_MAX = 840.0
+STATE_DIM = 7  # 6 joint angles + 1 gripper position
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("convert")
+
+
+def normalize_gripper(pos: int) -> float:
+    return float(pos) / GRIPPER_RAW_MAX
+
+
+def step_state(step: dict) -> np.ndarray:
+    joints = step.get("joint_positions") or []
+    if len(joints) != 6:
+        raise ValueError(
+            f"step {step.get('step_index')} has {len(joints)} joint_positions, expected 6"
+        )
+    if "gripper_position" not in step:
+        raise ValueError(f"step {step.get('step_index')} missing gripper_position")
+    return np.asarray(
+        list(joints) + [normalize_gripper(step["gripper_position"])],
+        dtype=np.float32,
+    )
+
+
+def load_episode(sess_dir: Path):
+    """Returns (steps, image_keys) where steps is a list of dicts and image_keys
+    is the sorted list of camera field names present (e.g. ["image", "image_1"])."""
+    jl = sess_dir / "steps.jsonl"
+    if not jl.exists():
+        return None, None
+    steps = [json.loads(line) for line in jl.read_text().splitlines() if line.strip()]
+    if len(steps) < 2:
+        return None, None
+    image_keys = sorted(k for k in steps[0].keys() if k == "image" or k.startswith("image_"))
+    return steps, image_keys
+
+
+def encode_jpeg(path: Path) -> bytes:
+    """Re-encode any image to JPEG bytes for consistent storage."""
+    img = Image.open(path).convert("RGB")
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", quality=92)
+    return buf.getvalue()
+
+
+def cam_field_name(image_key: str) -> str:
+    """Map "image"->"observation.images.cam_0", "image_1"->"observation.images.cam_1"."""
+    if image_key == "image":
+        return "observation.images.cam_0"
+    suffix = image_key.split("_", 1)[1]
+    return f"observation.images.cam_{suffix}"
+
+
+def build_frames(steps, sess_dir: Path, image_keys, episode_index: int,
+                 task_index: int, global_index_start: int):
+    """Returns (rows, num_frames). rows is a list of dicts ready for a DataFrame."""
+    states = np.stack([step_state(s) for s in steps])  # (N, 7)
+    actions = np.empty_like(states)
+    actions[:-1] = states[1:]
+    actions[-1] = states[-1]  # terminal: no movement
+
+    rows = []
+    t0 = None
+    for i, s in enumerate(steps):
+        # parse ISO timestamp to seconds-since-episode-start
+        ts = pd.Timestamp(s["timestamp"]).timestamp()
+        if t0 is None:
+            t0 = ts
+        row = {
+            "observation.state": states[i].tolist(),
+            "action": actions[i].tolist(),
+            "timestamp": float(ts - t0),
+            "frame_index": i,
+            "episode_index": episode_index,
+            "index": global_index_start + i,
+            "task_index": task_index,
+            "next.done": bool(s.get("is_last", i == len(steps) - 1)),
+            "next.reward": 0.0,
+        }
+        for k in image_keys:
+            rel = s.get(k)
+            if not rel:
+                raise ValueError(f"episode {sess_dir.name} step {i} missing {k}")
+            img_bytes = encode_jpeg(sess_dir / rel)
+            row[cam_field_name(k)] = {"bytes": img_bytes, "path": None}
+        rows.append(row)
+    return rows, len(steps)
+
+
+def write_parquet(rows, parquet_path: Path, image_fields):
+    df = pd.DataFrame(rows)
+    table = pa.Table.from_pandas(df, preserve_index=False)
+    parquet_path.parent.mkdir(parents=True, exist_ok=True)
+    pq.write_table(table, parquet_path, compression="snappy")
+
+
+def compute_stats(all_states, all_actions):
+    """Per-feature mean/std/min/max for state and action."""
+    def stats(arr):
+        return {
+            "mean": arr.mean(axis=0).tolist(),
+            "std": (arr.std(axis=0) + 1e-8).tolist(),
+            "min": arr.min(axis=0).tolist(),
+            "max": arr.max(axis=0).tolist(),
+            "count": int(arr.shape[0]),
+        }
+    return {
+        "observation.state": stats(np.stack(all_states)),
+        "action": stats(np.stack(all_actions)),
+    }
+
+
+def write_meta(out_dir: Path, episodes_meta, tasks, fps, image_keys, stats,
+               total_frames, image_shape):
+    meta = out_dir / "meta"
+    meta.mkdir(parents=True, exist_ok=True)
+
+    with (meta / "tasks.jsonl").open("w") as f:
+        for ti, task in enumerate(tasks):
+            f.write(json.dumps({"task_index": ti, "task": task}) + "\n")
+
+    with (meta / "episodes.jsonl").open("w") as f:
+        for em in episodes_meta:
+            f.write(json.dumps(em) + "\n")
+
+    features = {
+        "observation.state": {
+            "dtype": "float32",
+            "shape": [STATE_DIM],
+            "names": ["j0", "j1", "j2", "j3", "j4", "j5", "gripper"],
+        },
+        "action": {
+            "dtype": "float32",
+            "shape": [STATE_DIM],
+            "names": ["j0", "j1", "j2", "j3", "j4", "j5", "gripper"],
+        },
+        "timestamp": {"dtype": "float32", "shape": [1], "names": None},
+        "frame_index": {"dtype": "int64", "shape": [1], "names": None},
+        "episode_index": {"dtype": "int64", "shape": [1], "names": None},
+        "index": {"dtype": "int64", "shape": [1], "names": None},
+        "task_index": {"dtype": "int64", "shape": [1], "names": None},
+        "next.done": {"dtype": "bool", "shape": [1], "names": None},
+        "next.reward": {"dtype": "float32", "shape": [1], "names": None},
+    }
+    for k in image_keys:
+        features[cam_field_name(k)] = {
+            "dtype": "image",
+            "shape": list(image_shape),
+            "names": ["height", "width", "channel"],
+        }
+
+    info = {
+        "codebase_version": "v2.0",
+        "robot_type": "xarm",
+        "total_episodes": len(episodes_meta),
+        "total_frames": total_frames,
+        "total_tasks": len(tasks),
+        "total_videos": 0,
+        "total_chunks": 1,
+        "chunks_size": 1000,
+        "fps": fps,
+        "splits": {"train": f"0:{len(episodes_meta)}"},
+        "data_path": "data/chunk-{episode_chunk:03d}/episode_{episode_index:06d}.parquet",
+        "video_path": None,
+        "features": features,
+    }
+    (meta / "info.json").write_text(json.dumps(info, indent=2))
+    (meta / "stats.json").write_text(json.dumps(stats, indent=2))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--data-root", required=True, help="dir containing <session>/steps.jsonl")
+    ap.add_argument("--output-dir", required=True, help="LeRobot v2 dataset output dir")
+    ap.add_argument("--fps", type=int, default=10)
+    args = ap.parse_args()
+
+    data_root = Path(args.data_root)
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    sessions = sorted(p for p in data_root.iterdir() if p.is_dir())
+    log.info("found %d session dirs in %s", len(sessions), data_root)
+
+    tasks = []
+    task_to_index = {}
+    episodes_meta = []
+    all_states, all_actions = [], []
+    total_frames = 0
+    image_keys_global = None
+    image_shape = None
+
+    for ep_idx, sess in enumerate(sessions):
+        steps, image_keys = load_episode(sess)
+        if steps is None:
+            log.warning("skipping %s (no/empty steps.jsonl)", sess.name)
+            continue
+        if image_keys_global is None:
+            image_keys_global = image_keys
+            sample_img = Image.open(sess / steps[0][image_keys[0]])
+            w, h = sample_img.size
+            image_shape = (h, w, 3)
+        elif image_keys != image_keys_global:
+            raise ValueError(
+                f"episode {sess.name} cameras {image_keys} differ from first {image_keys_global}"
+            )
+
+        task = steps[0].get("language_instruction", "")
+        if task not in task_to_index:
+            task_to_index[task] = len(tasks)
+            tasks.append(task)
+        ti = task_to_index[task]
+
+        rows, n_frames = build_frames(steps, sess, image_keys, ep_idx, ti, total_frames)
+        for r in rows:
+            all_states.append(np.asarray(r["observation.state"], dtype=np.float32))
+            all_actions.append(np.asarray(r["action"], dtype=np.float32))
+
+        parquet_path = out_dir / "data" / "chunk-000" / f"episode_{ep_idx:06d}.parquet"
+        write_parquet(rows, parquet_path, image_keys)
+        log.info("wrote %s (%d frames, task=%r)", parquet_path.name, n_frames, task)
+
+        episodes_meta.append({
+            "episode_index": ep_idx,
+            "tasks": [task],
+            "length": n_frames,
+        })
+        total_frames += n_frames
+
+    if not episodes_meta:
+        raise SystemExit("no episodes converted")
+
+    stats = compute_stats(all_states, all_actions)
+    write_meta(out_dir, episodes_meta, tasks, args.fps,
+               image_keys_global, stats, total_frames, image_shape)
+    log.info("done: %d episodes, %d frames, %d tasks → %s",
+             len(episodes_meta), total_frames, len(tasks), out_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/cmd/vla/infer_smolvla.py
+++ b/cmd/vla/infer_smolvla.py
@@ -1,0 +1,204 @@
+"""Drive a Viam robot with a fine-tuned SmolVLA policy.
+
+Loop: read images + robot state → policy.select_action(...) → command joint
+positions and gripper position → repeat.
+
+Action format must match training (convert_to_lerobot.py):
+  [j0, j1, j2, j3, j4, j5, gripper_norm]
+  - j0..j5: target joint positions (radians)
+  - gripper_norm: target gripper position in [0, 1]; multiplied by 840 for the
+    raw xArm gripper position.
+
+Env vars (required):
+  VIAM_API_KEY, VIAM_API_KEY_ID
+
+Usage:
+  VIAM_API_KEY=... VIAM_API_KEY_ID=... \\
+  python infer_smolvla.py \\
+      --model-path outputs/smolvla/checkpoints/last/pretrained_model \\
+      --host vinopart.abc123.viam.cloud \\
+      --arm left-arm \\
+      --gripper left-gripper \\
+      --camera right-cam \\
+      --camera left-cam \\
+      --instruction "grab the black block and put it in the blue bowl"
+"""
+
+import argparse
+import asyncio
+import io
+import logging
+import os
+import time
+from pathlib import Path
+
+import numpy as np
+import torch
+from PIL import Image
+
+from viam.components.arm import Arm
+from viam.components.camera import Camera
+from viam.components.gripper import Gripper
+from viam.proto.component.arm import JointPositions
+from viam.robot.client import RobotClient
+
+GRIPPER_RAW_MAX = 840.0
+
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger("smolvla-infer")
+
+
+def load_policy(model_path: Path, device: str):
+    """Import lazily so the file imports cleanly without lerobot installed."""
+    from lerobot.common.policies.smolvla.modeling_smolvla import SmolVLAPolicy
+
+    log.info("loading SmolVLA policy from %s", model_path)
+    t0 = time.time()
+    policy = SmolVLAPolicy.from_pretrained(str(model_path))
+    policy.to(device)
+    policy.eval()
+    log.info("policy ready on %s in %.1fs", device, time.time() - t0)
+    return policy
+
+
+def image_to_tensor(image: Image.Image, device: str) -> torch.Tensor:
+    """PIL RGB → (1, 3, H, W) float tensor in [0, 1]."""
+    arr = np.asarray(image.convert("RGB"), dtype=np.float32) / 255.0
+    t = torch.from_numpy(arr).permute(2, 0, 1).unsqueeze(0)  # (1, 3, H, W)
+    return t.to(device)
+
+
+def build_state(joints: list[float], gripper_pos: int) -> np.ndarray:
+    if len(joints) != 6:
+        raise RuntimeError(f"expected 6 joints from arm, got {len(joints)}")
+    return np.asarray(
+        list(joints) + [float(gripper_pos) / GRIPPER_RAW_MAX],
+        dtype=np.float32,
+    )
+
+
+async def gripper_position(gripper: Gripper) -> int:
+    res = await gripper.do_command({"get": True})
+    pos = res.get("pos")
+    if pos is None:
+        raise RuntimeError(f"gripper get returned no 'pos': {res}")
+    return int(pos)
+
+
+async def run(args):
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if device == "cpu":
+        log.warning("running inference on CPU — will be slow")
+
+    policy = load_policy(Path(args.model_path), device)
+
+    api_key = os.environ.get("VIAM_API_KEY")
+    api_key_id = os.environ.get("VIAM_API_KEY_ID")
+    if not api_key or not api_key_id:
+        raise SystemExit("VIAM_API_KEY and VIAM_API_KEY_ID env vars are required")
+
+    log.info("connecting to robot %s", args.host)
+    opts = RobotClient.Options.with_api_key(api_key=api_key, api_key_id=api_key_id)
+    robot = await RobotClient.at_address(args.host, opts)
+
+    try:
+        arm = Arm.from_robot(robot, args.arm)
+        gripper = Gripper.from_robot(robot, args.gripper)
+        cams = [Camera.from_robot(robot, name) for name in args.camera]
+        log.info("connected: arm=%s gripper=%s cameras=%s",
+                 args.arm, args.gripper, args.camera)
+
+        steps = 1 if args.dry_run else args.max_steps
+        if args.dry_run:
+            log.info("DRY RUN: one step, no robot motion")
+
+        for step in range(steps):
+            t_step = time.time()
+
+            # --- read observation ---
+            t = time.time()
+            joints = (await arm.get_joint_positions()).values
+            grip = await gripper_position(gripper)
+            state = build_state(list(joints), grip)
+            log.debug("step %d: state %.2f / pose=%s grip=%d (%.2fs)",
+                      step, state[-1], list(state[:6]), grip, time.time() - t)
+
+            t = time.time()
+            cam_tensors = {}
+            for i, cam in enumerate(cams):
+                named, _ = await cam.get_images()
+                if not named:
+                    raise RuntimeError(f"camera {args.camera[i]} returned no images")
+                img = Image.open(io.BytesIO(named[0].data)).convert("RGB")
+                cam_tensors[f"observation.images.cam_{i}"] = image_to_tensor(img, device)
+            log.debug("step %d: cams in %.2fs", step, time.time() - t)
+
+            observation = {
+                "observation.state": torch.from_numpy(state).unsqueeze(0).to(device),
+                "task": [args.instruction],
+                **cam_tensors,
+            }
+
+            # --- predict ---
+            t = time.time()
+            with torch.inference_mode():
+                action_t = policy.select_action(observation)
+            action = action_t.squeeze(0).detach().cpu().numpy().astype(np.float32)
+            log.info(
+                "step %d action: joints=%s grip_norm=%.3f (infer %.2fs)",
+                step,
+                np.array2string(action[:6], precision=3, suppress_small=True),
+                float(action[6]),
+                time.time() - t,
+            )
+
+            target_joints = action[:6].tolist()
+            target_grip = int(round(float(action[6]) * GRIPPER_RAW_MAX))
+            target_grip = max(0, min(int(GRIPPER_RAW_MAX), target_grip))
+
+            if args.dry_run:
+                log.info("step %d: dry-run, skipping motion (total %.2fs)",
+                         step, time.time() - t_step)
+                continue
+
+            # --- apply action ---
+            t = time.time()
+            await asyncio.gather(
+                arm.move_to_joint_positions(JointPositions(values=target_joints)),
+                gripper.do_command({"set": float(target_grip)}),
+            )
+            log.info("step %d: moved in %.2fs (total %.2fs)",
+                     step, time.time() - t, time.time() - t_step)
+
+            if args.sleep > 0:
+                await asyncio.sleep(args.sleep)
+    finally:
+        await robot.close()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model-path", required=True,
+                    help="dir containing the fine-tuned SmolVLA checkpoint")
+    ap.add_argument("--host", required=True, help="Viam robot FQDN")
+    ap.add_argument("--arm", default="left-arm")
+    ap.add_argument("--gripper", default="left-gripper")
+    ap.add_argument("--camera", action="append", required=True,
+                    help="camera name; pass multiple times for multi-cam (must match training)")
+    ap.add_argument("--instruction", default="grab the cup")
+    ap.add_argument("--max-steps", type=int, default=200)
+    ap.add_argument("--sleep", type=float, default=0.0,
+                    help="seconds to sleep between steps")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="run one step, log predicted action, do NOT command the robot")
+    args = ap.parse_args()
+    asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/cmd/vla/requirements.txt
+++ b/cmd/vla/requirements.txt
@@ -5,6 +5,11 @@ tokenizers==0.19.1
 timm==0.9.10
 huggingface_hub<0.24
 peft==0.11.1
+# convert_to_lerobot.py + train_smolvla.py
+pandas
+pyarrow
+# lerobot installs separately to pick up SmolVLA extras:
+#   pip install "lerobot[smolvla] @ git+https://github.com/huggingface/lerobot.git"
 # OpenVLA's pin. Newer accelerate (>=0.31) regressed the bnb 4-bit path:
 # dispatch_model() calls .to() unconditionally on single-device bnb models,
 # which bnb refuses with "ValueError: .to is not supported for 4-bit ...".

--- a/cmd/vla/train_smolvla.py
+++ b/cmd/vla/train_smolvla.py
@@ -1,0 +1,76 @@
+"""Fine-tune SmolVLA on a LeRobot v2 dataset produced by convert_to_lerobot.py.
+
+Wraps `lerobot.scripts.train` with sensible defaults for SmolVLA fine-tuning
+on a small, single-arm dataset.
+
+Requirements:
+  pip install lerobot[smolvla]
+  # or, from source:
+  # pip install "lerobot @ git+https://github.com/huggingface/lerobot.git"
+
+Usage:
+  python train_smolvla.py \
+      --dataset-dir lerobot-dataset \
+      --output-dir outputs/smolvla \
+      --steps 20000
+
+The dataset must be on disk in LeRobot v2 layout (see convert_to_lerobot.py).
+LeRobot's training script expects a `repo_id` — for local datasets, it reads
+from `LEROBOT_HOME/<repo_id>` by default. We pass `--dataset.root` to point
+at our local path so the repo_id is just a label.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dataset-dir", required=True,
+                    help="local LeRobot v2 dataset dir (output of convert_to_lerobot.py)")
+    ap.add_argument("--output-dir", default="outputs/smolvla",
+                    help="checkpoint + log output dir")
+    ap.add_argument("--policy-path", default="lerobot/smolvla_base",
+                    help="HF repo id or local path to base SmolVLA checkpoint")
+    ap.add_argument("--repo-id", default="local/pouring-demo",
+                    help="logical dataset name (any label, dataset is loaded from --dataset-dir)")
+    ap.add_argument("--steps", type=int, default=20000)
+    ap.add_argument("--batch-size", type=int, default=8)
+    ap.add_argument("--lr", type=float, default=1e-4)
+    ap.add_argument("--save-freq", type=int, default=2000)
+    ap.add_argument("--num-workers", type=int, default=4)
+    ap.add_argument("--device", default="cuda")
+    ap.add_argument("--wandb", action="store_true")
+    args, passthrough = ap.parse_known_args()
+
+    dataset_dir = Path(args.dataset_dir).resolve()
+    if not (dataset_dir / "meta" / "info.json").exists():
+        raise SystemExit(f"{dataset_dir}/meta/info.json not found — is this a LeRobot v2 dataset?")
+
+    cmd = [
+        sys.executable, "-m", "lerobot.scripts.train",
+        f"--policy.path={args.policy_path}",
+        f"--dataset.repo_id={args.repo_id}",
+        f"--dataset.root={dataset_dir}",
+        f"--output_dir={args.output_dir}",
+        f"--steps={args.steps}",
+        f"--batch_size={args.batch_size}",
+        f"--policy.optimizer_lr={args.lr}",
+        f"--save_freq={args.save_freq}",
+        f"--num_workers={args.num_workers}",
+        f"--policy.device={args.device}",
+        f"--wandb.enable={'true' if args.wandb else 'false'}",
+    ]
+    cmd.extend(passthrough)
+
+    print("running:", " ".join(cmd))
+    env = os.environ.copy()
+    env.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+    sys.exit(subprocess.call(cmd, env=env))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds `convert_to_lerobot.py`: turns `capture-direct` `steps.jsonl` data into a LeRobot v2 dataset (joint positions + normalized gripper as state; next-step state as action; multi-camera images stored as JPEG in parquet)
- Adds `train_smolvla.py`: thin wrapper around `lerobot.scripts.train` with SmolVLA defaults; reads the local converted dataset via \`--dataset.root\`
- Adds `infer_smolvla.py`: closed-loop Viam controller that reads joints, gripper position, and cameras, runs \`SmolVLAPolicy.select_action\`, and sends absolute joint targets + denormalized gripper position back to the robot
- \`requirements.txt\`: adds \`pandas\` + \`pyarrow\` for the converter; LeRobot install documented inline

Stacked on top of #43 since the converter and inference both depend on the gripper-state field added there.

## Test plan
- [ ] Run \`convert_to_lerobot.py\` on existing \`openvla-export/\` data, verify per-episode parquet + meta files are produced and shapes look right
- [ ] Spot-check a parquet with \`pd.read_parquet(...)\` to confirm state/action dimensions, image bytes
- [ ] Install LeRobot on the GPU box and run \`train_smolvla.py\` for a few hundred steps to verify the dataset loads
- [ ] Run \`infer_smolvla.py --dry-run\` against the robot to verify the action prediction path works end-to-end (no robot motion)
- [ ] Short \`--max-steps 5\` real run with e-stop ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)