### PR TITLE
Show SAM segmentation highlight in demo UI

### DIFF
--- a/pour/vinoweb/src/RobotApp.svelte
+++ b/pour/vinoweb/src/RobotApp.svelte
@@ -3,6 +3,7 @@
   import { useRobotClient } from "@viamrobotics/svelte-sdk";
   import { GenericServiceClient } from "@viamrobotics/sdk";
   import { ArmClient } from "@viamrobotics/sdk";
+  import { VisionClient } from "@viamrobotics/sdk";
   import { Struct, type JsonValue } from "@bufbuild/protobuf";
   import MainContent from "./lib/MainContent.svelte";
   import Status from "./lib/status.svelte";
@@ -30,6 +31,18 @@
     waiting: "Please enjoy!",
     "manual mode": "Manual mode active",
   };
+
+  // Statuses where the pouring demo is actively running. In any other status
+  // (standby, waiting, manual mode) we show the SAM segmenter still images
+  // instead of the live camera streams.
+  const demoRunningStatuses = new Set<StatusKey>([
+    "looking",
+    "picking",
+    "prepping",
+    "pouring",
+    "placing",
+  ]);
+  const showStillImages = (s: StatusKey) => !demoRunningStatuses.has(s);
 
   // --- Keyboard controls for debugging ---
   function handleKeydown(event: KeyboardEvent) {
@@ -67,6 +80,7 @@
         partID: "xxx",
         label: "Left Camera",
       },
+      stillImageUrl: null as string | null,
     },
     {
       joints: rightJoints,
@@ -76,8 +90,34 @@
         partID: "xxx",
         label: "Right Camera",
       },
+      stillImageUrl: null as string | null,
     },
   ]);
+
+  // --- Vision services for standby still images (sam2 segmenters) ---
+  const visionServiceNames = ["sam2-segmenter-left", "sam2-segmenter-right"];
+  // Format enum values from viam.component.camera.v1.Format
+  const FORMAT_JPEG = 3;
+  const FORMAT_PNG = 4;
+  function imageToDataUrl(image: {
+    format: number;
+    image: Uint8Array;
+  }): string | null {
+    if (!image.image || image.image.length === 0) return null;
+    const mime =
+      image.format === FORMAT_PNG ? "image/png" : "image/jpeg";
+    // Copy into a fresh ArrayBuffer to satisfy strict BlobPart typing
+    // (the proto-generated Uint8Array has an ArrayBufferLike backing store).
+    const buf = new Uint8Array(image.image.byteLength);
+    buf.set(image.image);
+    const blob = new Blob([buf.buffer], { type: mime });
+    return URL.createObjectURL(blob);
+  }
+  function setStillImageUrl(index: number, url: string | null) {
+    const prev = panesData[index].stillImageUrl;
+    panesData[index].stillImageUrl = url;
+    if (prev) URL.revokeObjectURL(prev);
+  }
 
   // --- Robot client and polling logic ---
   const robotClientStore = useRobotClient(() => "xxx");
@@ -89,6 +129,80 @@
   let leftArm: ArmClient | null = null;
   let rightArm: ArmClient | null = null;
 
+  // -- Vision (sam2 segmenters for still-image standby view) ---
+  let visionClients: (VisionClient | null)[] = [null, null];
+  let imagePollingHandle: ReturnType<typeof setInterval> | null = null;
+  let imagePollingInterval = 1000; // ms; sam2 capture is relatively slow
+  let imageCaptureInFlight = [false, false];
+  // Per-pane failure tracking so a missing/disabled vision service doesn't
+  // get hammered forever. After ERROR_THRESHOLD consecutive errors we throttle
+  // retries to BACKOFF_MS; any successful call resets the counter.
+  let consecutiveErrors = [0, 0];
+  let nextRetryAt = [0, 0];
+  const ERROR_THRESHOLD = 3;
+  const BACKOFF_MS = 15000;
+
+  async function captureStillImage(index: number) {
+    const client = visionClients[index];
+    if (!client) return;
+    if (imageCaptureInFlight[index]) return;
+    // Respect backoff window for a pane whose vision service keeps failing.
+    if (
+      consecutiveErrors[index] >= ERROR_THRESHOLD &&
+      Date.now() < nextRetryAt[index]
+    ) {
+      return;
+    }
+    imageCaptureInFlight[index] = true;
+    try {
+      const result = await client.captureAllFromCamera(
+        // The vision service config already specifies its camera_name; passing
+        // an empty string lets the service use its own configured camera.
+        "",
+        {
+          returnImage: true,
+          // We ask for detections only so we can gate on their presence --
+          // they're never drawn on the image.
+          returnDetections: true,
+          returnClassifications: false,
+          returnObjectPointClouds: false,
+        }
+      );
+      consecutiveErrors[index] = 0;
+      const hasDetection = (result.detections?.length ?? 0) > 0;
+      if (hasDetection && result.image) {
+        const url = imageToDataUrl(result.image);
+        if (url) {
+          setStillImageUrl(index, url);
+          panesData = panesData;
+          return;
+        }
+      }
+      // No detection (or no usable image) -> fall back to the live camera.
+      if (panesData[index].stillImageUrl) {
+        setStillImageUrl(index, null);
+        panesData = panesData;
+      }
+    } catch (err) {
+      consecutiveErrors[index] += 1;
+      nextRetryAt[index] = Date.now() + BACKOFF_MS;
+      if (consecutiveErrors[index] === 1 || consecutiveErrors[index] === ERROR_THRESHOLD) {
+        console.warn(
+          `[${visionServiceNames[index]}] captureAllFromCamera failed (errors=${consecutiveErrors[index]}):`,
+          err
+        );
+      }
+      // Fall back to the live camera stream whenever the vision call fails so
+      // the user never sees a stale overlay when the service is down.
+      if (panesData[index].stillImageUrl) {
+        setStillImageUrl(index, null);
+        panesData = panesData;
+      }
+    } finally {
+      imageCaptureInFlight[index] = false;
+    }
+  }
+
   $effect(() => {
     const robotClient = robotClientStore.current;
     $inspect(robotClient, "robotClient");
@@ -96,6 +210,23 @@
       if (!leftArm) leftArm = new ArmClient(robotClient, "left-arm");
       if (!rightArm) rightArm = new ArmClient(robotClient, "right-arm");
       if (!generic) generic = new GenericServiceClient(robotClient, "cart");
+      for (let i = 0; i < visionServiceNames.length; i++) {
+        if (!visionClients[i]) {
+          visionClients[i] = new VisionClient(
+            robotClient,
+            visionServiceNames[i]
+          );
+        }
+      }
+
+      // --- Still-image capture loop (when the demo isn't actively running) ---
+      if (!imagePollingHandle) {
+        imagePollingHandle = setInterval(() => {
+          if (!showStillImages(status)) return;
+          captureStillImage(0);
+          captureStillImage(1);
+        }, imagePollingInterval);
+      }
 
       pollingHandle = setInterval(async () => {
         // --- Status ---
@@ -152,7 +283,29 @@
         clearInterval(pollingHandle);
         pollingHandle = null;
       }
+      if (imagePollingHandle) {
+        clearInterval(imagePollingHandle);
+        imagePollingHandle = null;
+      }
+      for (let i = 0; i < panesData.length; i++) {
+        if (panesData[i].stillImageUrl) {
+          URL.revokeObjectURL(panesData[i].stillImageUrl as string);
+          panesData[i].stillImageUrl = null;
+        }
+      }
     };
+  });
+
+  // Drop the still images as soon as the demo begins running so the live
+  // camera streams take over immediately.
+  $effect(() => {
+    if (!showStillImages(status)) {
+      for (let i = 0; i < panesData.length; i++) {
+        if (panesData[i].stillImageUrl) {
+          setStillImageUrl(i, null);
+        }
+      }
+    }
   });
 </script>
 

--- a/pour/vinoweb/src/lib/CameraFeed.svelte
+++ b/pour/vinoweb/src/lib/CameraFeed.svelte
@@ -8,13 +8,18 @@
     partID: string;
     label: string;
     overlay?: Snippet;
+    stillImageUrl?: string | null;
   }
 
-  let { name, partID, label, overlay }: Props = $props();
+  let { name, partID, label, overlay, stillImageUrl }: Props = $props();
 </script>
 
 <div class="camera-feed">
-  <CameraStream {name} {partID} />
+  {#if stillImageUrl}
+    <img class="still-image" src={stillImageUrl} alt={label} />
+  {:else}
+    <CameraStream {name} {partID} />
+  {/if}
   {#if overlay}
     <div class="overlay left">
       {@render overlay()}
@@ -44,6 +49,13 @@
     width: 100%;
     height: 100%;
     object-fit: cover;
+  }
+
+  .still-image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
   }
 
   .camera-label {

--- a/pour/vinoweb/src/lib/MainContent.svelte
+++ b/pour/vinoweb/src/lib/MainContent.svelte
@@ -16,6 +16,7 @@
     joints: Joint[];
     tableTitle?: string;
     camera: CameraConfig;
+    stillImageUrl?: string | null;
   }
 
   interface Props {
@@ -43,6 +44,7 @@
             name={panes[0].camera.name}
             partID={panes[0].camera.partID}
             label={panes[0].camera.label}
+            stillImageUrl={panes[0].stillImageUrl}
             overlay={status === "picking" ? table : undefined}
           />
         {/snippet}
@@ -59,6 +61,7 @@
               name={panes[1].camera.name}
               partID={panes[1].camera.partID}
               label={panes[1].camera.label}
+              stillImageUrl={panes[1].stillImageUrl}
             />
           {/snippet}
         </DataPane>


### PR DESCRIPTION
We've introduced a SAM2 object detection module to the pouring demo and this PR introduces the object detection object overlay to the frontend app.

Running the SAM2 module is still optional in this PR. If the SAM2 overlay components are disabled or unresponsive, the frontend will fallback to the camera stream of the real sense component.

This is what the change looks like:
<img width="1490" height="762" alt="Screenshot 2026-05-07 at 12 49 29 PM" src="https://github.com/user-attachments/assets/3b4cf51b-605e-4760-bd94-d768cbb01d67" />
