### PR TITLE
write bad plan files to /plans instead of /tmp

### DIFF
--- a/pour/vinocart.go
+++ b/pour/vinocart.go
@@ -10,6 +10,7 @@ import (
 	"io/fs"
 	"net/http"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -45,10 +46,18 @@ const bottleName = "bottle-top"
 const cupTopName = "cup-top"
 const gripperToCupCenterHack float64 = -35
 
-// planDir is where bad plan debug files are written. The data manager service
-// is configured with this path in additional_sync_paths so files are uploaded
-// to Viam cloud and then deleted from disk.
-const planDir = "/plans"
+// planDir is where bad plan debug files are written.
+//
+// Data manager can be configured with this path in additional_sync_paths so
+// files are uploaded to Viam cloud and then deleted from disk.
+var planDir = func() string {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return "/tmp/viam-plans"
+	}
+
+	return filepath.Join(cacheDir, "viam-plans")
+}()
 
 var VinoCartModel = NamespaceFamily.WithModel("vinocart")
 var noObjects = fmt.Errorf("no objects")
@@ -1057,7 +1066,7 @@ func (vc *VinoCart) Pour(ctx context.Context) error {
 				vc.logger.Warnf("[bottle-to-cup-align][try %d] debug written to %s", try, fn)
 			}
 			lastErr = fmt.Errorf("[bottle-to-cup-align][try %d] pos too far: %v", try, alignL2)
-			// On all but the final try, replan 
+			// On all but the final try, replan
 			if try < maxAlignTries {
 				vc.logger.Warnf("[bottle-to-cup-align][try %d] L2 too high, replanning...", try)
 				alignPlan, _, err = armplanning.PlanMotion(ctx, vc.logger, alignReq)

--- a/pour/vinocart.go
+++ b/pour/vinocart.go
@@ -110,7 +110,7 @@ func NewVinoCart(ctx context.Context, conf *Config, c *Pour1Components, client r
 	vc.cupTop = referenceframe.NewLinkInFrame(
 		vc.conf.GripperName,
 		spatialmath.NewPose(
-			r3.Vector{X: vc.conf.cupGripHeightOffset(), Y: -75, Z: -15},
+			r3.Vector{X: vc.conf.cupGripHeightOffset(), Y: -75, Z: -35},
 			&spatialmath.OrientationVectorDegrees{OX: 1},
 		),
 		cupTopName,

--- a/pour/vinocart.go
+++ b/pour/vinocart.go
@@ -45,6 +45,11 @@ const bottleName = "bottle-top"
 const cupTopName = "cup-top"
 const gripperToCupCenterHack float64 = -35
 
+// planDir is where bad plan debug files are written. The data manager service
+// is configured with this path in additional_sync_paths so files are uploaded
+// to Viam cloud and then deleted from disk.
+const planDir = "/plans"
+
 var VinoCartModel = NamespaceFamily.WithModel("vinocart")
 var noObjects = fmt.Errorf("no objects")
 
@@ -1041,7 +1046,10 @@ func (vc *VinoCart) Pour(ctx context.Context) error {
 		alignL2 := referenceframe.InputsL2Distance(alignJoints, alignGoalJoints)
 		vc.logger.Infof("[bottle-to-cup-align][try %d] InputsL2Distance: %v", try, alignL2)
 		if alignL2 > 1.3 {
-			fn := fmt.Sprintf("/tmp/align-plan-bad-try-%d.json", try)
+			if mkErr := os.MkdirAll(planDir, 0o755); mkErr != nil {
+				vc.logger.Errorf("[bottle-to-cup-align][try %d] failed to create %s: %v", try, planDir, mkErr)
+			}
+			fn := fmt.Sprintf("%s/align-plan-bad-try-%d-%d.json", planDir, try, time.Now().Unix())
 			debugErr := alignReq.WriteToFile(fn)
 			if debugErr != nil {
 				vc.logger.Errorf("[bottle-to-cup-align][try %d] failed to write debug: %v", try, debugErr)
@@ -1360,7 +1368,10 @@ func (vc *VinoCart) SetupPourPositions(ctx context.Context) (*PourPositions, err
 			d := referenceframe.InputsL2Distance(startJoints, myJoints)
 			vc.logger.Infof("\t InputsL2Distance: %v", d)
 			if d > 0.2 {
-				fn := "/tmp/pour-plan-bad.json"
+				if mkErr := os.MkdirAll(planDir, 0o755); mkErr != nil {
+					vc.logger.Errorf("failed to create %s: %v", planDir, mkErr)
+				}
+				fn := fmt.Sprintf("%s/pour-plan-bad-%d.json", planDir, time.Now().Unix())
 				if writeErr := req.WriteToFile(fn); writeErr != nil {
 					vc.logger.Errorf("failed to write pour debug: %v", writeErr)
 				}

--- a/pour/vinocart.go
+++ b/pour/vinocart.go
@@ -110,7 +110,7 @@ func NewVinoCart(ctx context.Context, conf *Config, c *Pour1Components, client r
 	vc.cupTop = referenceframe.NewLinkInFrame(
 		vc.conf.GripperName,
 		spatialmath.NewPose(
-			r3.Vector{X: vc.conf.cupGripHeightOffset(), Y: -75, Z: -35},
+			r3.Vector{X: vc.conf.cupGripHeightOffset(), Y: -75, Z: -15},
 			&spatialmath.OrientationVectorDegrees{OX: 1},
 		),
 		cupTopName,


### PR DESCRIPTION
## Summary

Write bad-plan debug JSON files to `/plans/` instead of `/tmp/` so they can be picked up by the data manager's `additional_sync_paths` without exposing the rest of `/tmp` to sync-and-delete.

## Changes

- Added `planDir = "/tmp/viam-plans"` constant
- `align-plan-bad-try-N.json` and `pour-plan-bad.json` now write to `/plans/`
- Each file name now includes a unix timestamp so retries no longer overwrite each other
- `os.MkdirAll(planDir, 0o755)` ensures the directory exists before each write

## Required config change

On each machine running this module, update the `data_manager` service config:

```json
"additional_sync_paths": ["/tmp/viam-plans"]