### PR TITLE
switch to using SAM2 for cup pointcloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,19 +19,44 @@ Once planning is done the demo executes - liquid is dispensed into the cups.
 
 ## Attributes
 
-The following attributes must be specified:
+The `viam:pouring-demo:vinocart` service takes the following attributes:
 
-| Name                       | Type    | Inclusion    | Description                                                                                            |
-| -------------------------- | ------- | ------------ | ------------------------------------------------------------------------------------------------------ |
-| `arm_name`                 | string  | **Required** | The name of the arm which will do the pouring.                                                         |
-| `camera_name`              | string  | **Required** | The name of the camera which will take images of the table.                                            |
-| `circle_detection_service` | string  | **Required** | The name of the vision service which detects the number of cups and their positions.                   |
-| `weight_sensor_name`       | string  | **Required** | The name of weight sensor which is used to determine how heavy the bottle is.                          |                                                                           |
-| `delta_x_pos`              | float64 | **Required** | A skew parameter used to adjust the postions of cups when translating from pixel space into the world. |
-| `delta_y_pos`              | float64 | **Required** | A skew parameter used to adjust the postions of cups when translating from pixel space into the world. |
-| `delta_x_neg`              | float64 | **Required** | A skew parameter used to adjust the postions of cups when translating from pixel space into the world. |
-| `delta_y_neg`              | float64 | **Required** | A skew parameter used to adjust the postions of cups when translating from pixel space into the world. |
-| `cpu_threads`              | int     | Optional     | Number of threads to use for motion planning. Half the availible threads will be used if unsupplied.
+| Name                          | Type    | Inclusion              | Description                                                                                                          |
+| ----------------------------- | ------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `arm_name`                    | string  | **Required**           | The arm that picks and places the cup.                                                                              |
+| `gripper_name`                | string  | **Required**           | The gripper on the cup arm.                                                                                          |
+| `camera_name`                 | string  | **Required**           | The camera used to capture pick-quality images of the grabbed cup.                                                  |
+| `bottle_height`               | float64 | **Required**           | Height of the bottle (mm); used to locate the bottle tip (`bottle-top` frame) for pouring.                          |
+| `cup_cloud_cam`               | string  | Required for picking   | Camera that returns a single point cloud of just the cup. The cup is found and measured directly from this cloud.   |
+| `bottle_arm`                  | string  | Required for pouring   | The arm that holds and tilts the bottle.                                                                            |
+| `bottle_gripper`              | string  | Required for pouring   | The gripper on the bottle arm.                                                                                      |
+| `Positions`                   | object  | Required for motion    | Named stage/step joint positions (toggleswitch components) the arms replay. Note: capitalized key, no JSON tag.     |
+| `glass_pour_cam`              | string  | Optional               | Camera that watches the glass fill during a pour.                                                                   |
+| `glass_pour_motion_threshold` | float64 | Optional               | Grayscale-delta threshold for detecting liquid hitting the glass (default 4).                                       |
+| `pour_glass_find_service`     | string  | Optional               | Vision service that locates and crops the glass for pour monitoring.                                                |
+| `glass_fullness_service`      | string  | Optional               | Vision (classification) service for ML-based glass-fullness detection.                                              |
+| `use_glass_fullness_model`    | bool    | Optional               | Use the ML fullness model instead of the default image-delta motion detection.                                      |
+| `pick_quality_service`        | string  | Optional               | Vision (classification) service that grades whether a cup pick was good.                                            |
+| `cup_grip_height_offset`      | float64 | Optional               | Distance (mm) below the cup rim to grip/release the cup (default 25).                                               |
+| `cup_top_offset_x`/`_y`/`_z`  | float64 | Optional               | Offsets (mm) of the `cup-top` frame relative to the gripper (defaults: X = `cup_grip_height_offset`, Y = -75, Z = -25). |
+| `cup`                         | object  | Optional               | "Standardized cup" validation spec a detected cup is checked against. See below.                                    |
+| `Handoff`                     | bool    | Optional               | Allow handing the cup from the bottle arm to the cup arm when the cup arm can't reach it. Capitalized key, no JSON tag. |
+| `loop`                        | bool    | Optional               | Run the demo continuously: find cup → pour → wait for the area to clear → repeat.                                   |
+
+### `cup` (standardized-cup validation)
+
+After the cup point cloud is measured (center, height, width, point count), it is validated against this spec. Every field is optional with a sensible default; omit the whole `cup` block to use all defaults.
+
+| Name                  | Type    | Inclusion | Description                                                                                              |
+| --------------------- | ------- | --------- | ------------------------------------------------------------------------------------------------------- |
+| `min_height`          | float64 | Optional  | Minimum valid cup height in mm (default 30).                                                             |
+| `max_height`          | float64 | Optional  | Maximum valid cup height in mm (default 400).                                                            |
+| `min_width`           | float64 | Optional  | Minimum valid cup width in mm (default 20).                                                              |
+| `max_width`           | float64 | Optional  | Maximum valid cup width in mm (default 200).                                                             |
+| `gripper_max_opening` | float64 | Optional  | Gripper's maximum span in mm. When > 0, rejects cups too wide for the gripper to wrap around. Disabled (0) by default. |
+| `grip_clearance`      | float64 | Optional  | Margin (mm) beyond the cup width the gripper needs to wrap; also inflates the cup collision obstacle (default 10). |
+| `min_points`          | int     | Optional  | Minimum number of cloud points required to trust a detection — guards against sparse/see-through clouds (default 20). |
+| `nominal_height`      | float64 | Optional  | Fallback cup height (mm) used to derive a release height before the first cup is picked this run (default 120). |
 
 ## What to do if something goes wrong
 

--- a/cmd/tools/cmd-tools.go
+++ b/cmd/tools/cmd-tools.go
@@ -135,13 +135,11 @@ func realMain() error {
 	case "full-demo-wait":
 		return vc.WaitForCupAndGo(ctx)
 	case "find-cups":
-		cups, err := vc.FindCups(ctx)
+		cup, err := vc.FindCup(ctx)
 		if err != nil {
 			return err
 		}
-		for idx, c := range cups {
-			logger.Infof("cup %d : %v", idx, c)
-		}
+		logger.Infof("cup: %v", cup)
 		return nil
 	case "pour-motion-demo":
 		pp, err := vc.SetupPourPositions(ctx)

--- a/pour/config.go
+++ b/pour/config.go
@@ -54,7 +54,10 @@ type Config struct {
 	GlassPourCam             string  `json:"glass_pour_cam"`
 	GlassPourMotionThreshold float64 `json:"glass_pour_motion_threshold"`
 
-	CupFinderService string `json:"cup_finder_service"` // find the cups on the table
+	// CupCloudCam is a camera that returns a single point cloud of just the cup
+	// (it does the segmentation under the hood). Replaces the old multi-object
+	// cup_finder_service.
+	CupCloudCam string `json:"cup_cloud_cam"`
 
 	Positions map[string]ConfigStatePostions
 
@@ -63,10 +66,12 @@ type Config struct {
 
 	Handoff bool
 
-	// cup and bottle params, required
+	// bottle params, required
 	BottleHeight float64 `json:"bottle_height"`
-	CupHeight    float64 `json:"cup_height"`
-	CupWidth     float64 `json:"cup_width"`
+
+	// Cup is the "standardized cup" spec a detected cup is validated against.
+	// All fields are optional with sensible defaults (see cup_geometry.go).
+	Cup CupSpec `json:"cup"`
 
 	// optional offset for gripper height when grabbing/placing cup
 	CupGripHeightOffset float64 `json:"cup_grip_height_offset"`
@@ -118,14 +123,11 @@ func (cfg *Config) Validate(path string) ([]string, []string, error) {
 	if cfg.BottleHeight == 0 {
 		return nil, nil, fmt.Errorf("bottle_height cannot be unset")
 	}
-	if cfg.CupHeight == 0 {
-		return nil, nil, fmt.Errorf("cup_height cannot be unset")
-	}
 
 	optionals := []string{}
 
-	if cfg.CupFinderService != "" {
-		optionals = append(optionals, cfg.CupFinderService)
+	if cfg.CupCloudCam != "" {
+		deps = append(deps, cfg.CupCloudCam)
 	}
 
 	if cfg.BottleGripper != "" {
@@ -144,13 +146,6 @@ func (cfg *Config) Validate(path string) ([]string, []string, error) {
 	}
 
 	return deps, optionals, nil
-}
-
-func (c *Config) cupWidth() float64 {
-	if c.CupWidth > 0 {
-		return c.CupWidth
-	}
-	return c.CupHeight * .6
 }
 
 func (c *Config) glassPourMotionThreshold() float64 {
@@ -200,7 +195,7 @@ type Pour1Components struct {
 	Motion motion.Service
 	Rfs    framesystem.Service
 
-	CupFinder vision.Service
+	CupCloudCam camera.Camera
 
 	Positions map[string]StagePositions
 
@@ -262,8 +257,8 @@ func Pour1ComponentsFromDependencies(config *Config, deps resource.Dependencies)
 		}
 	}
 
-	if config.CupFinderService != "" {
-		c.CupFinder, err = vision.FromProvider(deps, config.CupFinderService)
+	if config.CupCloudCam != "" {
+		c.CupCloudCam, err = camera.FromProvider(deps, config.CupCloudCam)
 		if err != nil {
 			return nil, err
 		}

--- a/pour/cup_geometry.go
+++ b/pour/cup_geometry.go
@@ -1,0 +1,164 @@
+package pour
+
+import (
+	"fmt"
+
+	"github.com/golang/geo/r3"
+	"go.viam.com/rdk/pointcloud"
+)
+
+// CupGeometry is the measured geometry of a cup, derived directly from a point
+// cloud whose every point is assumed to belong to the cup. The cloud is
+// expected in the world frame with the table at Z=0 (same as the rest of the
+// demo), so RimZ is the cup rim's absolute height in world coordinates.
+type CupGeometry struct {
+	Center    r3.Vector // bounding-box center; X,Y give the grasp axis
+	RimZ      float64   // world Z of the rim (cloud MaxZ), used for approach height
+	Height    float64   // physical height (MaxZ-MinZ), used for validation
+	Width     float64   // mean of the X and Y extents
+	NumPoints int
+}
+
+// cupGeometryFromPointCloud measures a cup from a cloud that already represents
+// only the cup. MetaData().Center() is the bounding-box center ((max+min)/2),
+// which is robust to point density -- a sparse / see-through cup still pins the
+// extents, so the center and dimensions stay meaningful with few points.
+func cupGeometryFromPointCloud(pc pointcloud.PointCloud) CupGeometry {
+	md := pc.MetaData()
+	return CupGeometry{
+		Center:    md.Center(),
+		RimZ:      md.MaxZ,
+		Height:    md.MaxZ - md.MinZ,
+		Width:     ((md.MaxX - md.MinX) + (md.MaxY - md.MinY)) / 2,
+		NumPoints: pc.Size(),
+	}
+}
+
+func (g CupGeometry) String() string {
+	return fmt.Sprintf("CupGeometry(center=%v rimZ=%.1f height=%.1f width=%.1f points=%d)",
+		g.Center, g.RimZ, g.Height, g.Width, g.NumPoints)
+}
+
+// CupSpec is the "standardized cup" the demo validates a detected cup against.
+// Every field is optional: the accessor methods below supply defaults so a
+// minimal config still works, and any value can be overridden in config.
+//
+// This replaces the old approach of matching detections to exact configured
+// dimensions (cup_height/cup_width) within a fixed tolerance, which existed to
+// pick the right blob out of a noisy multi-object segmentation. The new camera
+// returns a single cup-only cloud, so instead we measure the cup and check it
+// is (a) dense enough to trust, (b) a sensible size for the demo, and (c)
+// something the gripper can physically close around.
+type CupSpec struct {
+	MinHeight float64 `json:"min_height"`
+	MaxHeight float64 `json:"max_height"`
+	MinWidth  float64 `json:"min_width"`
+	MaxWidth  float64 `json:"max_width"`
+
+	// GripperMaxOpening is the gripper's physical maximum span (mm). When 0 the
+	// gripper-wrap check is skipped (default), so a guessed value never rejects
+	// a cup -- set it to enforce that the claws can actually close around the cup.
+	GripperMaxOpening float64 `json:"gripper_max_opening"`
+
+	// GripClearance is the margin (mm) the gripper needs beyond the measured cup
+	// width to wrap around it. Also used to inflate the cup collision obstacle.
+	GripClearance float64 `json:"grip_clearance"`
+
+	// MinPoints rejects clouds too sparse for the bounding box to be trusted.
+	MinPoints int `json:"min_points"`
+
+	// NominalHeight is a fallback cup height (mm) used to derive a release height
+	// before any cup has been measured this run (see VinoCart.releaseZ).
+	NominalHeight float64 `json:"nominal_height"`
+}
+
+// Permissive defaults: ranges are wide so the demo isn't surprised into
+// rejecting a valid cup. Tighten them in config for stricter validation.
+const (
+	defaultCupMinHeight     = 30.0
+	defaultCupMaxHeight     = 400.0
+	defaultCupMinWidth      = 20.0
+	defaultCupMaxWidth      = 200.0
+	defaultCupGripClearance = 10.0
+	defaultCupMinPoints     = 20
+	defaultCupNominalHeight = 120.0
+)
+
+func (s *CupSpec) minHeight() float64 {
+	if s.MinHeight > 0 {
+		return s.MinHeight
+	}
+	return defaultCupMinHeight
+}
+
+func (s *CupSpec) maxHeight() float64 {
+	if s.MaxHeight > 0 {
+		return s.MaxHeight
+	}
+	return defaultCupMaxHeight
+}
+
+func (s *CupSpec) minWidth() float64 {
+	if s.MinWidth > 0 {
+		return s.MinWidth
+	}
+	return defaultCupMinWidth
+}
+
+func (s *CupSpec) maxWidth() float64 {
+	if s.MaxWidth > 0 {
+		return s.MaxWidth
+	}
+	return defaultCupMaxWidth
+}
+
+func (s *CupSpec) gripClearance() float64 {
+	if s.GripClearance > 0 {
+		return s.GripClearance
+	}
+	return defaultCupGripClearance
+}
+
+func (s *CupSpec) minPoints() int {
+	if s.MinPoints > 0 {
+		return s.MinPoints
+	}
+	return defaultCupMinPoints
+}
+
+func (s *CupSpec) nominalHeight() float64 {
+	if s.NominalHeight > 0 {
+		return s.NominalHeight
+	}
+	return defaultCupNominalHeight
+}
+
+// CupValidation is the result of checking a measured cup against the CupSpec.
+// Reasons lists every failed check, so callers (and the UI/logs) can see why a
+// cup was rejected rather than just a pass/fail bool.
+type CupValidation struct {
+	Valid   bool
+	Reasons []string
+}
+
+func (s *CupSpec) validate(g CupGeometry) CupValidation {
+	v := CupValidation{Valid: true}
+	fail := func(format string, args ...interface{}) {
+		v.Valid = false
+		v.Reasons = append(v.Reasons, fmt.Sprintf(format, args...))
+	}
+
+	if g.NumPoints < s.minPoints() {
+		fail("too few points (%d < %d): cloud not trustworthy", g.NumPoints, s.minPoints())
+	}
+	if g.Height < s.minHeight() || g.Height > s.maxHeight() {
+		fail("height %.1f outside [%.1f, %.1f]", g.Height, s.minHeight(), s.maxHeight())
+	}
+	if g.Width < s.minWidth() || g.Width > s.maxWidth() {
+		fail("width %.1f outside [%.1f, %.1f]", g.Width, s.minWidth(), s.maxWidth())
+	}
+	if opening := s.GripperMaxOpening; opening > 0 && g.Width+s.gripClearance() > opening {
+		fail("width %.1f + clearance %.1f exceeds gripper opening %.1f", g.Width, s.gripClearance(), opening)
+	}
+	return v
+}

--- a/pour/vinocart.go
+++ b/pour/vinocart.go
@@ -32,7 +32,6 @@ import (
 	"go.viam.com/rdk/services/motion"
 	"go.viam.com/rdk/spatialmath"
 	"go.viam.com/rdk/utils"
-	viz "go.viam.com/rdk/vision"
 
 	"github.com/erh/vmodutils"
 	"github.com/erh/vmodutils/touch"
@@ -190,6 +189,10 @@ type VinoCart struct {
 	statusLock sync.Mutex
 	status     string
 
+	// lastGraspZ is the world Z used to grab the most recent cup. Reused as the
+	// release height when putting a cup back, since no live cloud exists then.
+	lastGraspZ float64
+
 	latestPour    time.Time
 	pourInspector *pourInsepctor
 	cancelPour    context.CancelFunc
@@ -339,18 +342,16 @@ func (vc *VinoCart) WaitForCupAndGo(ctx context.Context) error {
 	vc.logger.Infof("waiting for area to be clear")
 
 	for {
-		objects, err := vc.FindCups(ctx)
+		cup, err := vc.FindCup(ctx)
+		if err == noObjects {
+			// no valid cup present -> area is clear
+			return nil
+		}
 		if err != nil {
 			return err
 		}
 
-		vc.logger.Infof("num objects while waiting: %v", len(objects))
-		for _, o := range objects {
-			vc.logger.Infof("\t objects: %v", o)
-		}
-		if len(objects) == 0 {
-			return nil
-		}
+		vc.logger.Infof("cup still present while waiting: %v", cup)
 	}
 }
 
@@ -602,47 +603,31 @@ func (vc *VinoCart) Touch(ctx context.Context) error {
 	}
 
 	start := time.Now()
-	objects, err := vc.FindCups(ctx)
+	cup, err := vc.FindCup(ctx)
 	if err != nil {
 		return err
 	}
 
-	vc.logger.Infof("num objects: %v in %v", len(objects), time.Since(start))
-	for _, o := range objects {
-		vc.logger.Infof("\t objects: %v", o)
-	}
-
-	if len(objects) == 0 {
-		return noObjects
-	}
-
-	if len(objects) > 1 {
-		return fmt.Errorf("too many objects %d", len(objects))
-	}
+	vc.logger.Infof("found cup in %v: %v", time.Since(start), cup)
 
 	vc.setStatus("picking")
 
-	obj := objects[0]
+	// Stash the grasp height so PutBack/Reset can release the cup at the same
+	// height later, when no live cloud is available.
+	vc.lastGraspZ = cup.RimZ - vc.conf.cupGripHeightOffset()
 
 	// -- setup world frame
-
-	// Build a synthetic cup obstacle that uses the *detected* center but the
-	// *configured* cup_width x cup_width x cup_height for dimensions. The
-	// point-cloud detector returns a noisy bounding box (e.g. 96x105x124mm
-	// on one frame, 61x91x120mm on the next for the same physical cup), and
-	// feeding that raw geometry into the planner caused it to disagree with
-	// itself between approach orientations (claws "fit" one frame, collide
-	// the next). Anchoring on config dims stabilises planning and lines the
-	// live service up with what cup-heatmap simulates. The validator in
-	// FindCups / FilterObjects still gates on detected vs config +/- 25mm,
-	// so wildly wrong objects are still rejected upstream.
 	//
-	// Temporary until SAM2 productionizes a tight, repeatable bounding box.
-	md := obj.MetaData()
-	cupCenter := md.Center()
+	// Build the cup collision obstacle straight from the measured cloud. The new
+	// cup-only camera gives a clean, repeatable bounding box, so (unlike the old
+	// noisy multi-object segmenter) we can trust the measured dimensions instead
+	// of substituting configured ones. The box is centered on the bbox center
+	// (same point we grasp) and inflated by grip clearance so a single-view
+	// cloud that slightly under-measures the cup still over-covers as an obstacle.
+	margin := vc.conf.Cup.gripClearance()
 	cupObs, err := spatialmath.NewBox(
-		spatialmath.NewPoseFromPoint(cupCenter),
-		r3.Vector{X: vc.conf.cupWidth(), Y: vc.conf.cupWidth(), Z: vc.conf.CupHeight},
+		spatialmath.NewPoseFromPoint(cup.Center),
+		r3.Vector{X: cup.Width + margin, Y: cup.Width + margin, Z: cup.Height},
 		"cup",
 	)
 	if err != nil {
@@ -651,7 +636,7 @@ func (vc *VinoCart) Touch(ctx context.Context) error {
 	obstacles := []*referenceframe.GeometriesInFrame{
 		referenceframe.NewGeometriesInFrame("world", []spatialmath.Geometry{cupObs}),
 	}
-	vc.logger.Infof("add cup as obstacle (configured dims, detected center %v): %v", cupCenter, cupObs)
+	vc.logger.Infof("add cup as obstacle (measured, center %v): %v", cup.Center, cupObs)
 
 	worldState, err := referenceframe.NewWorldState(obstacles, nil)
 	if err != nil {
@@ -675,7 +660,7 @@ func (vc *VinoCart) Touch(ctx context.Context) error {
 	approaches := []*referenceframe.PoseInFrame{}
 
 	for _, tryO := range choices {
-		goToPose := vc.getApproachPoint(obj, 100, tryO)
+		goToPose := vc.getApproachPoint(cup, 100, tryO)
 		approaches = append(approaches, goToPose)
 		vc.logger.Infof("trying to move to %v", goToPose.Pose())
 
@@ -704,7 +689,7 @@ func (vc *VinoCart) Touch(ctx context.Context) error {
 
 	if vc.conf.Handoff && err != nil {
 
-		err2 := vc.handoffCupBottleToCupArm(ctx, worldState, approaches, choices, obj)
+		err2 := vc.handoffCupBottleToCupArm(ctx, worldState, approaches, choices, cup)
 		if err2 == nil {
 			return nil
 		}
@@ -722,7 +707,7 @@ func (vc *VinoCart) Touch(ctx context.Context) error {
 		return err
 	}
 
-	goToPose := vc.getApproachPoint(obj, gripperToCupCenterHack, o)
+	goToPose := vc.getApproachPoint(cup, gripperToCupCenterHack, o)
 	vc.logger.Infof("going to move to %v", goToPose)
 
 	err = moveWithLinearConstraint(ctx, vc.c.Motion, vc.c.Gripper.Name(), goToPose, "touch-pickup")
@@ -733,7 +718,7 @@ func (vc *VinoCart) Touch(ctx context.Context) error {
 	return vc.GrabCup(ctx)
 }
 
-func (vc *VinoCart) handoffCupBottleToCupArm(ctx context.Context, worldState *referenceframe.WorldState, approaches []*referenceframe.PoseInFrame, choices []*spatialmath.OrientationVectorDegrees, obj *viz.Object) error {
+func (vc *VinoCart) handoffCupBottleToCupArm(ctx context.Context, worldState *referenceframe.WorldState, approaches []*referenceframe.PoseInFrame, choices []*spatialmath.OrientationVectorDegrees, cup *CupGeometry) error {
 	for idx, goToPose := range approaches {
 		vc.logger.Infof("trying to move (2) to %v", goToPose.Pose())
 
@@ -753,7 +738,7 @@ func (vc *VinoCart) handoffCupBottleToCupArm(ctx context.Context, worldState *re
 
 		// we found a path!
 
-		goToPose = vc.getApproachPoint(obj, gripperToCupCenterHack, choices[idx])
+		goToPose = vc.getApproachPoint(cup, gripperToCupCenterHack, choices[idx])
 		vc.logger.Infof("going to move (2) to %v", goToPose)
 
 		err = moveWithLinearConstraint(ctx, vc.c.Motion, vc.c.BottleGripper.Name(), goToPose, "handoff-pickup")
@@ -770,7 +755,7 @@ func (vc *VinoCart) handoffCupBottleToCupArm(ctx context.Context, worldState *re
 		}
 
 		// move to known spot
-		goToPose = vc.getApproachPoint(obj, 150, choices[idx])
+		goToPose = vc.getApproachPoint(cup, 150, choices[idx])
 		err = moveWithLinearConstraint(ctx, vc.c.Motion, vc.c.BottleGripper.Name(), goToPose, "handoff-lift")
 		if err != nil {
 			return err
@@ -783,7 +768,7 @@ func (vc *VinoCart) handoffCupBottleToCupArm(ctx context.Context, worldState *re
 		}
 
 		// backup
-		goToPose = vc.getApproachPoint(obj, 250, choices[idx])
+		goToPose = vc.getApproachPoint(cup, 250, choices[idx])
 		err = moveWithLinearConstraint(ctx, vc.c.Motion, vc.c.BottleGripper.Name(), goToPose, "handoff-backup")
 		if err != nil {
 			return err
@@ -794,12 +779,9 @@ func (vc *VinoCart) handoffCupBottleToCupArm(ctx context.Context, worldState *re
 	return fmt.Errorf("no path for handoff")
 }
 
-func (vc *VinoCart) getApproachPoint(obj *viz.Object, deltaLinear float64, o *spatialmath.OrientationVectorDegrees) *referenceframe.PoseInFrame {
-	md := obj.MetaData()
-	c := md.Center()
-
-	p := touch.GetApproachPoint(c, deltaLinear, o)
-	p.Z = vc.conf.CupHeight - vc.conf.cupGripHeightOffset()
+func (vc *VinoCart) getApproachPoint(cup *CupGeometry, deltaLinear float64, o *spatialmath.OrientationVectorDegrees) *referenceframe.PoseInFrame {
+	p := touch.GetApproachPoint(cup.Center, deltaLinear, o)
+	p.Z = cup.RimZ - vc.conf.cupGripHeightOffset()
 
 	return referenceframe.NewPoseInFrame(
 		"world",
@@ -956,6 +938,16 @@ func (vc *VinoCart) goTo(ctx context.Context, poss ...toggleswitch.Switch) error
 	return multierr.Combine(errors...)
 }
 
+// releaseZ is the world Z to lower a held cup to before opening the gripper.
+// It reuses the height the cup was grabbed at this run; before any pick has
+// happened it falls back to the configured nominal cup height.
+func (vc *VinoCart) releaseZ() float64 {
+	if vc.lastGraspZ > 0 {
+		return vc.lastGraspZ
+	}
+	return vc.conf.Cup.nominalHeight() - vc.conf.cupGripHeightOffset()
+}
+
 func (vc *VinoCart) moveToCurrentXYAtCupHeight(ctx context.Context) error {
 	cur, err := vc.c.Motion.GetPose(ctx, vc.conf.GripperName, "world", vc.pourExtraFrames, nil)
 	if err != nil {
@@ -967,7 +959,7 @@ func (vc *VinoCart) moveToCurrentXYAtCupHeight(ctx context.Context) error {
 		spatialmath.NewPose(r3.Vector{
 			X: cur.Pose().Point().X,
 			Y: cur.Pose().Point().Y,
-			Z: vc.conf.CupHeight - vc.conf.cupGripHeightOffset(),
+			Z: vc.releaseZ(),
 		}, cur.Pose().Orientation()))
 
 	_, err = vc.c.Motion.Move(
@@ -1549,11 +1541,31 @@ func moveWithLinearConstraint(ctx context.Context, m motion.Service, n resource.
 	return err
 }
 
-func (vc *VinoCart) FindCups(ctx context.Context) ([]*viz.Object, error) {
-	objects, err := vc.c.CupFinder.GetObjectPointClouds(ctx, "", nil)
+// FindCup pulls a single cup-only point cloud from the cup-cloud camera,
+// measures it, and validates it against the configured CupSpec. It returns
+// noObjects when there is nothing on the table or when the detected object is
+// not a valid cup, so loop mode keeps waiting instead of erroring out.
+func (vc *VinoCart) FindCup(ctx context.Context) (*CupGeometry, error) {
+	if vc.c.CupCloudCam == nil {
+		return nil, fmt.Errorf("no cup_cloud_cam configured")
+	}
+
+	pc, err := vc.c.CupCloudCam.NextPointCloud(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return FilterObjects(objects, vc.conf.CupHeight, vc.conf.cupWidth(), 25, vc.logger), nil
+	if pc.Size() == 0 {
+		return nil, noObjects
+	}
+
+	g := cupGeometryFromPointCloud(pc)
+	vc.logger.Infof("FindCup: %v", g)
+
+	if res := vc.conf.Cup.validate(g); !res.Valid {
+		vc.logger.Infof("rejecting cup: %v", res.Reasons)
+		return nil, noObjects
+	}
+
+	return &g, nil
 }


### PR DESCRIPTION
## Summary

Replaces the cup-finding pick path with one built around a new camera that returns a single point cloud of just the cup. Instead of segmenting a noisy multi-object scene and matching each blob against hard-coded cup_height/cup_width within a fixed tolerance, we now measure the cup directly from the cloud and validate it against a configurable "standardized cup" spec. This removes a cluster of hard-coded geometry constants and makes the demo adaptable to different cups via config.

## What changed

  New: pour/cup_geometry.go
  - CupGeometry + cupGeometryFromPointCloud — derives center, rim height (MaxZ), physical height (MaxZ−MinZ), width, and point count from the cloud. Uses the bounding-box center, which stays meaningful for sparse / see-through cups.
  - CupSpec — the standardized-cup spec. Every field is optional with a sensible default supplied by accessor methods; any value can be overridden in config.
  - validate() → CupValidation{Valid, Reasons} checking: enough points (trustworthy cloud), height in range, width in range, and gripper can physically wrap (width + clearance ≤ gripper_max_opening). Collects every failure reason for logging. The gripper-wrap check is disabled unless gripper_max_opening is set, so a guessed value never silently rejects a valid cup.

  pour/vinocart.go
  - FindCups → FindCup: pulls one cloud via NextPointCloud, measures it, validates against CupSpec. Returns noObjects for an empty table or an invalid cup, so loop mode keeps waiting instead of erroring the run.
  - Touch: cup collision obstacle is now built from the measured geometry (centered on the bbox center, inflated by grip_clearance so a single-view under-measure still over-covers). Drops the synthetic-obstacle-from-config-dims workaround and the >1 objects guard.
  - getApproachPoint / handoffCupBottleToCupArm now take *CupGeometry; grasp Z = cup.RimZ − cup_grip_height_offset.
  - moveToCurrentXYAtCupHeight uses a new releaseZ() that reuses the stashed grasp height (lastGraspZ), falling back to nominal_height before the first pick — since no live cloud exists when placing a cup.
  - WaitForCupAndGo wait-for-clear loop adapted to the single-cup return.

  pour/config.go
  - Added cup_cloud_cam (the new camera) and cup (CupSpec).
  - Removed cup_height, cup_width, cupWidth(), the cup_height required-validation, and the old cup_finder_service / CupFinder vision.Service.

  cmd/tools/cmd-tools.go
  - find-cups CLI command updated to the single-cup return.

  README.md
  - Rewrote the Attributes table to match the current vinocart config (it previously documented a long-removed architecture: circle_detection_service, weight_sensor_name, delta_* skew params, cpu_threads). Added a sub-table for the new cup spec.        
