### PR TITLE
Add first_run script to install libnlopt0 on deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ ifeq ($(VIAM_TARGET_OS), windows)
 else
 	strip $(MODULE_BINARY)
 endif
-	tar czf $@ meta.json $(MODULE_BINARY) pour/vinoweb/dist
+	tar czf $@ meta.json first_run.sh $(MODULE_BINARY) pour/vinoweb/dist
 ifeq ($(VIAM_TARGET_OS), windows)
 	git checkout meta.json
 endif

--- a/first_run.sh
+++ b/first_run.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+sudo apt-get update
+sudo apt-get install -y libnlopt0

--- a/meta.json
+++ b/meta.json
@@ -34,6 +34,7 @@
         }
     ],
     "entrypoint": "bin/viam-pouring-demo",
+    "first_run": "first_run.sh",
     "build": {
         "build": "make module.tar.gz",
         "setup": "make setup",


### PR DESCRIPTION
Bundles first_run.sh into the module tarball and wires it into meta.json so libnlopt0 is installed when the module is first deployed to a machine.